### PR TITLE
Mark summary as an optional event field

### DIFF
--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -48,7 +48,7 @@ class Event(BaseModel):
     """A single event on a calendar."""
 
     id: Optional[str] = None
-    summary: str
+    summary: Optional[str] = None
     start: Datetime
     end: Datetime
     description: Optional[str]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -126,3 +126,40 @@ async def test_create_event(
             "end": {"date": end_date},
         },
     )
+
+
+async def test_event_missing_summary(
+    calendar_service: GoogleCalendarService,
+    events_list_items: Callable[[list[dict[str, Any]]], None],
+) -> None:
+    """Test list calendars API."""
+
+    events_list_items(
+        [
+            {
+                "id": "some-event-id-1",
+                "description": "Event description 1",
+                "start": {
+                    "date": "2022-04-13",
+                },
+                "end": {
+                    "date": "2022-04-14",
+                },
+                "status": "confirmed",
+                "transparency": "transparent",
+            },
+        ]
+    )
+
+    result = await calendar_service.async_list_events(
+        ListEventsRequest(calendar_id="some-calendar-id")
+    )
+    assert result.items == [
+        Event(
+            id="some-event-id-1",
+            description="Event description 1",
+            start=Datetime(date=datetime.date(2022, 4, 13)),
+            end=Datetime(date=datetime.date(2022, 4, 14)),
+            transparency="transparent",
+        )
+    ]


### PR DESCRIPTION
Mark summary as an optional event field to match api responses seen in in home assistant where events have no summary present.