### PR TITLE
Allow empty API responses for list calls

### DIFF
--- a/gcal_sync/api.py
+++ b/gcal_sync/api.py
@@ -23,7 +23,7 @@ def _api_time_format(date_time: datetime.datetime | None) -> str | None:
 class CalendarListResponse(BaseModel):
     """Api response containing a list of calendars."""
 
-    items: list[Calendar]
+    items: list[Calendar] = []
 
 
 class ListEventsRequest(BaseModel):
@@ -39,7 +39,7 @@ class ListEventsRequest(BaseModel):
 class ListEventsResponse(BaseModel):
     """Api response containing a list of events."""
 
-    items: list[Event] = Field(alias="items")
+    items: list[Event] = Field(default=[], alias="items")
     sync_token: Optional[str] = Field(default=None, alias="syncToken")
     page_token: Optional[str] = Field(default=None, alias="pageToken")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,6 +38,17 @@ async def test_list_calendars(
     ]
 
 
+async def test_list_calendars_empty_reply(
+    calendar_service: GoogleCalendarService, calendars_list: ApiResult
+) -> None:
+    """Test list calendars API."""
+
+    calendars_list({})
+
+    result = await calendar_service.async_list_calendars()
+    assert result.items == []
+
+
 async def test_list_events(
     calendar_service: GoogleCalendarService,
     events_list_items: Callable[[list[dict[str, Any]]], None],


### PR DESCRIPTION
Allow empty API responses for list calls, really just to make test setup easier.