### PR TITLE
update setup.cfg, exclude 'tests'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,9 @@ package_dir =
 
 [options.packages.find]
 where = .
+exclude =
+    tests
+    tests.*
 
 [options.package_data]
 rtsp_to_webrtc = py.typed


### PR DESCRIPTION
otherwise setup would try to install a package called tests at top level, which is bad style (and forbidden).