### PR TITLE
Cleanup and simplify list event APIs

### DIFF
--- a/gcal_sync/api.py
+++ b/gcal_sync/api.py
@@ -95,7 +95,6 @@ class _ListEventsResponseModel(SyncableResponse):
     """Api response containing a list of events."""
 
     items: List[Event] = []
-    timezone: Optional[str] = Field(default=None, alias="timeZone")
 
 
 class ListEventsResponse:
@@ -125,11 +124,6 @@ class ListEventsResponse:
     def page_token(self) -> str | None:
         """Return the page token in the response."""
         return self._model.page_token
-
-    @property
-    def timezone(self) -> str | None:
-        """Return the timezone in the response."""
-        return self._model.timezone
 
     async def __aiter__(self) -> AsyncIterator[ListEventsResponse]:
         """Async iterator to traverse through pages of responses."""
@@ -197,7 +191,7 @@ class GoogleCalendarService:
     ) -> _ListEventsResponseModel:
         """Return the list of events."""
         params = {
-            "maxResult": EVENT_PAGE_SIZE,
+            "maxResults": EVENT_PAGE_SIZE,
             "singleEvents": "true",
             "orderBy": "startTime",
             "fields": EVENT_API_FIELDS,

--- a/gcal_sync/auth.py
+++ b/gcal_sync/auth.py
@@ -46,7 +46,7 @@ class AbstractAuth(ABC):  # pylint: disable=too-few-public-methods
         headers = {AUTHORIZATION_HEADER: f"Bearer {access_token}"}
         if not (url.startswith("http://") or url.startswith("https://")):
             url = f"{self._host}/{url}"
-        _LOGGER.debug("request[%s]=%s", method, url)
+        _LOGGER.debug("request[%s]=%s %s", method, url, kwargs.get("params"))
         if method == "post" and "json" in kwargs:
             _LOGGER.debug("request[post json]=%s", kwargs["json"])
         return await self._websession.request(method, url, **kwargs, headers=headers)

--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -11,8 +11,8 @@ from pydantic import BaseModel, Field, root_validator
 
 DATE_STR_FORMAT = "%Y-%m-%d"
 EVENT_FIELDS = (
-    "id,summary,description,location,start,end,transparency,timeZone,eventType,"
-    "visibility,attendees,attendeesOmitted"
+    "id,summary,description,location,start,end,transparency"  # ,eventType,"
+    #    "visibility,attendees,attendeesOmitted"
 )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,11 @@ from gcal_sync.model import EVENT_FIELDS, Calendar, DateOrDatetime, Event
 
 from .conftest import ApiRequest, ApiResult
 
+EVENT_LIST_PARAMS = (
+    "maxResults=100&singleEvents=true&orderBy=startTime"
+    f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+)
+
 
 async def test_list_calendars(
     calendar_service_cb: Callable[[], Awaitable[GoogleCalendarService]],
@@ -96,8 +101,7 @@ async def test_list_events(
         ListEventsRequest(calendar_id="some-calendar-id")
     )
     assert url_request() == [
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&timeMin=2022-04-30T01:31:02%2B00:00"
     ]
     assert result.items == [
@@ -148,8 +152,7 @@ async def test_list_events_with_date_limit(
         ),
     )
     assert url_request() == [
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&timeMin=2022-04-13T07:30:12-06:00&timeMax=2022-04-13T09:30:12-06:00"
     ]
 
@@ -388,16 +391,13 @@ async def test_list_events_multiple_pages_with_iterator(
 
     assert url_request() == [
         # Request #1
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&timeMin=2022-04-30T01:31:02%2B00:00",
         # Request #2
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&pageToken=page-token-1&timeMin=2022-04-30T01:31:02%2B00:00",
         # Request #3
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&pageToken=page-token-2&timeMin=2022-04-30T01:31:02%2B00:00",
     ]
     assert items == [
@@ -437,8 +437,6 @@ async def test_list_event_url_encoding(
         ListEventsRequest(calendar_id="en.usa#holiday@group.v.calendar.google.com")
     )
     assert url_request() == [
-        "/calendars/en.usa#holiday@group.v.calendar.google.com/events?maxResult=100"
-        "&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/en.usa#holiday@group.v.calendar.google.com/events?{EVENT_LIST_PARAMS}"
         "&timeMin=2022-04-30T01:31:02%2B00:00"
     ]

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -17,6 +17,10 @@ from gcal_sync.sync import VERSION, CalendarEventSyncManager, CalendarListSyncMa
 from .conftest import ApiResult, ResponseResult
 
 CALENDAR_ID = "some-calendar-id"
+EVENT_LIST_PARAMS = (
+    "maxResults=100&singleEvents=true&orderBy=startTime"
+    f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+)
 
 
 @pytest.fixture(name="store")
@@ -216,8 +220,7 @@ async def test_event_lookup_items(
     sync = await event_sync_manager_cb()
     await sync.run()
     assert url_request() == [
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&timeMin=2022-03-08T00:31:02"
     ]
 
@@ -347,11 +350,9 @@ async def test_event_sync_date_pages(
     sync = await event_sync_manager_cb()
     await sync.run()
     assert url_request() == [
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&timeMin=2022-03-08T00:31:02",
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&pageToken=page-token-1&timeMin=2022-03-08T00:31:02",
     ]
 
@@ -375,14 +376,11 @@ async def test_event_sync_date_pages(
     )
     await sync.run()
     assert url_request() == [
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&timeMin=2022-03-08T00:31:02",
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&pageToken=page-token-1&timeMin=2022-03-08T00:31:02",
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&syncToken=sync-token-1",
     ]
 
@@ -438,11 +436,9 @@ async def test_event_sync_datetime_pages(
     sync = await event_sync_manager_cb()
     await sync.run()
     assert url_request() == [
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&timeMin=2022-03-08T00:31:02",
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&pageToken=page-token-1&timeMin=2022-03-08T00:31:02",
     ]
 
@@ -466,14 +462,11 @@ async def test_event_sync_datetime_pages(
     )
     await sync.run()
     assert url_request() == [
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&timeMin=2022-03-08T00:31:02",
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&pageToken=page-token-1&timeMin=2022-03-08T00:31:02",
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&syncToken=sync-token-1",
     ]
 
@@ -521,8 +514,7 @@ async def test_event_invalidated_sync_token(
     sync = await event_sync_manager_cb()
     await sync.run()
     assert url_request() == [
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&timeMin=2022-03-08T00:31:02"
     ]
 
@@ -566,11 +558,9 @@ async def test_event_invalidated_sync_token(
     )
     await sync.run()
     assert url_request() == [
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS}"
-        ")&syncToken=sync-token-1",
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
+        "&syncToken=sync-token-1",
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&timeMin=2022-03-08T00:31:02",
     ]
     result = await sync.store_service.async_list_events(LocalListEventsRequest())
@@ -617,8 +607,7 @@ async def test_event_token_version_invalidation(
     sync = await event_sync_manager_cb()
     await sync.run()
     assert url_request() == [
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&timeMin=2022-03-08T00:31:02"
     ]
 
@@ -651,8 +640,7 @@ async def test_event_token_version_invalidation(
         await sync.run()
 
     assert url_request() == [
-        "/calendars/some-calendar-id/events?maxResult=100&singleEvents=true&orderBy=startTime"
-        f"&fields=kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
+        f"/calendars/some-calendar-id/events?{EVENT_LIST_PARAMS}"
         "&timeMin=2022-03-08T00:31:02"
     ]
     result = await sync.store_service.async_list_events(LocalListEventsRequest())


### PR DESCRIPTION
Cleanup and simplify list event APIs:
- remove timezone list event response since its not used
- default to in memory store
- fix max results parameters