### PR TITLE
Add py.typed file for gcal sync

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ exclude =
     tests.*
 
 [options.package_data]
-rtsp_to_webrtc = py.typed
+gcal_sync = py.typed
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Add py.typed file for gcal sync to fix mypy typing imports.