### PR TITLE
Remove home assistant from project description

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = gcal-sync
 version = 0.10.0
-description = A python library for syncing Google Calendar to local storage for use in Home Assistant
+description = A python library for syncing Google Calendar to local storage
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/allenporter/gcal_sync


### PR DESCRIPTION
Remove home assistant from project description, since this is not a home assistant specific library.