### PR TITLE
Fix pydantic model default values

### DIFF
--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -29,10 +29,10 @@ class Calendar(BaseModel):
 class DateOrDatetime(BaseModel):
     """A date or datetime."""
 
-    date: Optional[datetime.date]
-    date_time: Optional[datetime.datetime] = Field(alias="dateTime")
+    date: Optional[datetime.date] = Field(default=None)
+    date_time: Optional[datetime.datetime] = Field(alias="dateTime", default=None)
     # Note: timezone is only used for creating new events
-    timezone: Optional[str] = Field(alias="timeZone")
+    timezone: Optional[str] = Field(alias="timeZone", default=None)
 
     @property
     def value(self) -> Union[datetime.date, datetime.datetime]:


### PR DESCRIPTION
Fix pydantic model default value so that mypy typing will work. It currently fails in pydnatic 1.10 and higher:
```
gcal_sync/model.py:139: error: Missing named argument "date_time" for "DateOrDatetime"
gcal_sync/model.py:139: error: Missing named argument "timezone" for "DateOrDatetime"
gcal_sync/model.py:141: error: Missing named argument "date_time" for "DateOrDatetime"
gcal_sync/model.py:141: error: Missing named argument "timezone" for "DateOrDatetime"
```