### PR TITLE
Prevent invalid requests during sync protocol

### DIFF
--- a/gcal_sync/sync.py
+++ b/gcal_sync/sync.py
@@ -17,6 +17,7 @@ from .api import (
     ListEventsRequest,
     SyncableRequest,
     SyncableResponse,
+    SyncEventsRequest,
     _ListEventsResponseModel,
 )
 from .const import CALENDAR_LIST_SYNC, EVENT_SYNC, ITEMS, SYNC_TOKEN, SYNC_TOKEN_VERSION
@@ -164,12 +165,11 @@ class CalendarEventSyncManager:
         """Run the event sync manager."""
 
         def new_request(sync_token: str | None) -> ListEventsRequest:
-            request = ListEventsRequest(calendar_id=self._calendar_id)
+            request = SyncEventsRequest(calendar_id=self._calendar_id)
             if not sync_token:
                 _LOGGER.debug(
                     "Performing full calendar sync for calendar %s", self._calendar_id
                 )
-                request.start_time = MIN_SYNC_DATETIME
             else:
                 _LOGGER.debug(
                     "Performing incremental sync for calendar %s (%s)",


### PR DESCRIPTION
Prevent invalid requests during sync protocol, separating out some of the request building logic between the normal flows and sync flows. This is a lot more verbose, but slightly easier to reason about given validation logic at a lower request level instead of multiple levels of default values.