### PR TITLE
Fix bug with date/datetime comparisons are in different units

### DIFF
--- a/gcal_sync/timeline.py
+++ b/gcal_sync/timeline.py
@@ -116,7 +116,7 @@ class EventIterable(Iterable[Event]):
         for event in iter(self._iterable):
             if event.recurrence:
                 continue
-            heapq.heappush(heap, (event.start.value, event))
+            heapq.heappush(heap, (event.start.normalize, event))
         while heap:
             (_, event) = heapq.heappop(heap)
             yield event

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -125,6 +125,56 @@ def test_iteration(timeline: Timeline) -> None:
     ]
 
 
+def test_date_and_datetimes() -> None:
+    """Test chronological iteration of a timeline with all day and non-all day events."""
+    timeline = calendar_timeline(
+        [
+            Event.parse_obj(
+                {
+                    "id": "some-event-id-2",
+                    "summary": "second",
+                    "start": {
+                        "date": "2000-2-1",
+                    },
+                    "end": {
+                        "date": "2000-2-2",
+                    },
+                }
+            ),
+            Event.parse_obj(
+                {
+                    "id": "some-event-id-1",
+                    "summary": "first",
+                    "start": {
+                        "dateTime": "2000-01-01T12:00:00Z",
+                    },
+                    "end": {
+                        "dateTime": "2000-01-01T12:30:00Z",
+                    },
+                },
+            ),
+            Event.parse_obj(
+                {
+                    "id": "some-event-id-3",
+                    "summary": "third",
+                    "start": {
+                        "date": "2000-3-1",
+                    },
+                    "end": {
+                        "date": "2000-3-2",
+                    },
+                },
+            ),
+        ]
+    )
+
+    assert [e.summary for e in timeline] == [
+        "first",
+        "second",
+        "third",
+    ]
+
+
 @pytest.mark.parametrize(
     "when,expected_events",
     [


### PR DESCRIPTION
Ensure date/datetime comparisons are in the same unit when doing comparisons. Dates are converted using the local timezone (see `util` methods for overrides)


```
  File "/home/allen/gcal_sync/gcal_sync/timeline.py", line 119, in __iter__
    heapq.heappush(heap, (event.start.value, event))
TypeError: can't compare datetime.datetime to datetime.date
```
