### PR TITLE
Adjust invalid RRULES from API when parsing

### DIFF
--- a/gcal_sync/timeline.py
+++ b/gcal_sync/timeline.py
@@ -12,8 +12,6 @@ import heapq
 import logging
 from collections.abc import Iterable, Iterator
 
-from dateutil import rrule
-
 from .iter import MergedIterable, RecurIterable
 from .model import DateOrDatetime, Event
 
@@ -159,6 +157,5 @@ def calendar_timeline(events: list[Event]) -> Timeline:
     for event in events:
         if not event.recurrence:
             continue
-        ruleset = rrule.rrulestr("\n".join(event.recurrence), dtstart=event.start.value)
-        iters.append(RecurIterable(RecurAdapter(event).get, ruleset))
+        iters.append(RecurIterable(RecurAdapter(event).get, event.rrule))
     return Timeline(MergedIterable(iters))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -594,3 +594,18 @@ def test_comparisons(
     assert event1 <= event2
     assert event2 >= event1
     assert event2 > event1
+
+
+def test_invalid_rrule() -> None:
+    """Test invalid RRULE parsing."""
+    with pytest.raises(
+        ValidationError, match=r"Recurrence rule had unexpected format.*"
+    ):
+        Event.parse_obj(
+            {
+                "summary": "Summary",
+                "start": {"date_time": "2012-11-27T18:00:00"},
+                "end": {"date_time": "2012-11-27T19:00:00"},
+                "recurrence": ["RRULE:FREQ=WEEKLY;UNTIL;BYDAY=TU"],
+            }
+        )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -596,7 +596,7 @@ def test_comparisons(
     assert event2 > event1
 
 
-def test_invalid_rrule() -> None:
+def test_invalid_rrule_until_format() -> None:
     """Test invalid RRULE parsing."""
     with pytest.raises(
         ValidationError, match=r"Recurrence rule had unexpected format.*"
@@ -607,5 +607,18 @@ def test_invalid_rrule() -> None:
                 "start": {"date_time": "2012-11-27T18:00:00"},
                 "end": {"date_time": "2012-11-27T19:00:00"},
                 "recurrence": ["RRULE:FREQ=WEEKLY;UNTIL;BYDAY=TU"],
+            }
+        )
+
+
+def test_invalid_rrule_until_time() -> None:
+    """Test invalid RRULE parsing."""
+    with pytest.raises(ValidationError, match=r"Recurrence rule had invalid UNTIL.*"):
+        Event.parse_obj(
+            {
+                "summary": "Summary",
+                "start": {"date_time": "2012-11-27T18:00:00"},
+                "end": {"date_time": "2012-11-27T19:00:00"},
+                "recurrence": ["RRULE:FREQ=WEEKLY;UNTIL=20220202T1234T;BYDAY=TU"],
             }
         )


### PR DESCRIPTION
Adjust invalid RRULES from API when parsing.

This involves manually parsing the rrule at a basic level and hacking on them in a minimal way to make them match the rfc and the rrule parsing library.