### PR TITLE
Use ical implementation of Timeline 

### DIFF
--- a/gcal_sync/api.py
+++ b/gcal_sync/api.py
@@ -30,7 +30,7 @@ from pydantic import BaseModel, Field, ValidationError, root_validator, validato
 from .auth import AbstractAuth
 from .const import ITEMS
 from .exceptions import ApiException
-from .model import EVENT_FIELDS, Calendar, DateOrDatetime, Event, EventStatusEnum
+from .model import EVENT_FIELDS, Calendar, Event, EventStatusEnum
 from .store import CalendarStore
 from .timeline import Timeline, calendar_timeline
 
@@ -449,15 +449,13 @@ class CalendarEventStoreService:
             return LocalListEventsResponse(
                 events=list(
                     timeline.overlapping(
-                        DateOrDatetime(date_time=request.start_time),
-                        DateOrDatetime(date_time=request.end_time),
+                        request.start_time,
+                        request.end_time,
                     )
                 )
             )
         return LocalListEventsResponse(
-            events=list(
-                timeline.active_after(DateOrDatetime(date_time=request.start_time))
-            )
+            events=list(timeline.active_after(request.start_time))
         )
 
     async def async_get_timeline(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -719,19 +719,15 @@ async def test_canceled_events(
     assert [event.summary for event in timeline] == ["Event 2", "Event 3"]
 
     event_iter = timeline.start_after(
-        DateOrDatetime.parse(
-            datetime.datetime(
-                2022, 4, 20, 23, 0, 0, tzinfo=zoneinfo.ZoneInfo("America/Regina")
-            )
+        datetime.datetime(
+            2022, 4, 20, 23, 0, 0, tzinfo=zoneinfo.ZoneInfo("America/Regina")
         )
     )
     assert [event.summary for event in event_iter] == ["Event 3"]
 
     event_iter = timeline.start_after(
-        DateOrDatetime.parse(
-            datetime.datetime(
-                2022, 4, 21, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo("America/Regina")
-            )
+        datetime.datetime(
+            2022, 4, 21, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo("America/Regina")
         )
     )
     assert [event.summary for event in event_iter] == []

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -835,7 +835,7 @@ async def test_event_sync_with_search(
     url_request: Callable[[], str],
     request_reset: Callable[[], str],
 ) -> None:
-    """Test syncing events with a search string."""
+    """Test syncing events with a minimum time of events to return."""
     service = await calendar_service_cb()
     sync = CalendarEventSyncManager(
         service,

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -214,32 +214,36 @@ def test_overlap(
     expected_events: list[str],
 ) -> None:
     """Test returning events on a particular day."""
-    assert [
-        e.summary
-        for e in timeline.overlapping(
-            DateOrDatetime.parse(start), DateOrDatetime.parse(end)
-        )
-    ] == expected_events
+    assert [e.summary for e in timeline.overlapping(start, end)] == expected_events
 
 
 def test_active_after(timeline: Timeline) -> None:
     """Test returning events on a particular day."""
-    events = [
-        e.summary
-        for e in timeline.active_after(DateOrDatetime.parse(datetime.date(2000, 2, 15)))
-    ]
+    events = [e.summary for e in timeline.active_after(datetime.date(2000, 2, 15))]
     assert events == ["third", "fourth"]
 
 
 @pytest.mark.parametrize(
     "at_datetime,expected_events",
     [
-        (datetime.datetime(2000, 1, 1, 11, 15), ["first"]),
-        (datetime.datetime(2000, 1, 1, 11, 59), []),
-        (datetime.datetime(2000, 1, 1, 12, 0), ["second"]),
-        (datetime.datetime(2000, 1, 1, 12, 30), ["second"]),
-        (datetime.datetime(2000, 1, 1, 12, 59), ["second"]),
-        (datetime.datetime(2000, 1, 1, 13, 0), []),
+        (
+            datetime.datetime(2000, 1, 1, 11, 15, tzinfo=datetime.timezone.utc),
+            ["first"],
+        ),
+        (datetime.datetime(2000, 1, 1, 11, 59, tzinfo=datetime.timezone.utc), []),
+        (
+            datetime.datetime(2000, 1, 1, 12, 0, tzinfo=datetime.timezone.utc),
+            ["second"],
+        ),
+        (
+            datetime.datetime(2000, 1, 1, 12, 30, tzinfo=datetime.timezone.utc),
+            ["second"],
+        ),
+        (
+            datetime.datetime(2000, 1, 1, 12, 59, tzinfo=datetime.timezone.utc),
+            ["second"],
+        ),
+        (datetime.datetime(2000, 1, 1, 13, 0, tzinfo=datetime.timezone.utc), []),
     ],
 )
 def test_at_instant(
@@ -249,18 +253,6 @@ def test_at_instant(
     assert [
         e.summary for e in calendar_times.at_instant(at_datetime)
     ] == expected_events
-
-
-@freeze_time("2000-01-01 12:30:00")
-def test_now(calendar_times: Timeline) -> None:
-    """Test events happening at the current time."""
-    assert [e.summary for e in calendar_times.now()] == ["second"]
-
-
-@freeze_time("2000-01-01 13:00:00")
-def test_now_no_match(calendar_times: Timeline) -> None:
-    """Test no events happening at the current time."""
-    assert [e.summary for e in calendar_times.now()] == []
 
 
 @freeze_time("2000-01-01 12:30:00")
@@ -404,9 +396,7 @@ def test_all_day_with_local_timezone(
 
     def start_after(dtstart: datetime.datetime) -> list[str]:
         nonlocal timeline
-        return [
-            e.summary for e in timeline.start_after(DateOrDatetime(date_time=dtstart))
-        ]
+        return [e.summary for e in timeline.start_after(dtstart)]
 
     local_before = dt_before.astimezone(local_tz)
     assert start_after(local_before) == ["event"]
@@ -526,11 +516,7 @@ async def test_all_day_iter_order(
         zoneinfo.ZoneInfo(time_zone),
     )
     events = timeline.overlapping(
-        DateOrDatetime.parse(
-            datetime.datetime(2022, 10, 6, 0, 0, 0, tzinfo=datetime.timezone.utc)
-        ),
-        DateOrDatetime.parse(
-            datetime.datetime(2022, 10, 9, 0, 0, 0, tzinfo=datetime.timezone.utc)
-        ),
+        datetime.datetime(2022, 10, 6, 0, 0, 0, tzinfo=datetime.timezone.utc),
+        datetime.datetime(2022, 10, 9, 0, 0, 0, tzinfo=datetime.timezone.utc),
     )
     assert [event.summary for event in events] == event_order


### PR DESCRIPTION
Use ical implementation of Timeline  so that it gets the shared performance wins put into the ical library. The previous library Timeline was very slow since it was copying events in and out of the heap.