### PR TITLE
Update API requests with necessary fields in masks

### DIFF
--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -32,7 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DATE_STR_FORMAT = "%Y-%m-%d"
 EVENT_FIELDS = (
-    "id,summary,description,location,start,end,transparency,status,eventType,"
+    "id,iCalUID,summary,start,end,description,location,transparency,status,eventType,"
     "visibility,attendees,attendeesOmitted,recurrence,recurringEventId,originalStartTime"
 )
 MIDNIGHT = datetime.time()

--- a/gcal_sync/sync.py
+++ b/gcal_sync/sync.py
@@ -37,7 +37,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 # Can be incremented to blow away existing store
-VERSION = 1
+VERSION = 2
 MIN_SYNC_DATETIME = datetime.datetime(2006, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
 
 T = TypeVar("T", bound=SyncableRequest)

--- a/gcal_sync/sync.py
+++ b/gcal_sync/sync.py
@@ -67,7 +67,7 @@ async def _run_sync(
     sync_token_version = store_data.get(SYNC_TOKEN_VERSION)
     if sync_token_version and sync_token_version < VERSION:
         _LOGGER.debug(
-            "Invaliding token with version {sync_token_version}, {TOKEN_VERSION}"
+            "Invaliding token with version %s, %s", sync_token_version, VERSION
         )
         store_data[SYNC_TOKEN] = None
         store_data[ITEMS] = {}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,6 +10,7 @@ import pytest
 from pydantic import ValidationError
 
 from gcal_sync.model import (
+    EVENT_FIELDS,
     Attendee,
     Calendar,
     DateOrDatetime,
@@ -626,3 +627,11 @@ def test_invalid_rrule_until_time() -> None:
                 "recurrence": ["RRULE:FREQ=WEEKLY;UNTIL=20220202T1234T;BYDAY=TU"],
             }
         )
+
+
+def test_event_fields_mask() -> None:
+    """Test that all fields in the pydantic model are specified in the field mask."""
+
+    assert EVENT_FIELDS == ",".join(
+        [field.alias for field in Event.__fields__.values()]
+    )


### PR DESCRIPTION
Update API requests with necessary fields in masks, and a test to prevent future regressions in field masks in the event messages.