### PR TITLE
Fix bug in recurrence event filtering exceptions

### DIFF
--- a/gcal_sync/api.py
+++ b/gcal_sync/api.py
@@ -528,15 +528,10 @@ class CalendarEventStoreService:
         """Get the timeline of events."""
         events_data = await self._lookup_events_data()
         _LOGGER.debug("Created timeline of %d events", len(events_data))
-
-        events: list[Event] = []
-        for data in events_data.values():
-            event = Event.parse_obj(data)
-            if event.status == EventStatusEnum.CANCELLED:
-                continue
-            events.append(event)
-
-        return calendar_timeline(events, tzinfo if tzinfo else datetime.timezone.utc)
+        return calendar_timeline(
+            [Event.parse_obj(data) for data in events_data.values()],
+            tzinfo if tzinfo else datetime.timezone.utc,
+        )
 
     async def async_add_event(self, event: Event) -> None:
         """Add the specified event to the calendar.

--- a/gcal_sync/timeline.py
+++ b/gcal_sync/timeline.py
@@ -8,7 +8,9 @@ like returning all events happening today or after a specific date.
 from __future__ import annotations
 
 import datetime
-from collections.abc import Generator, Iterable
+import logging
+from collections.abc import Generator, Iterable, Iterator
+from typing import TypeVar, Union
 
 from ical.iter import (
     LazySortableItem,
@@ -21,9 +23,13 @@ from ical.iter import (
 )
 from ical.timespan import Timespan
 
-from .model import DateOrDatetime, Event, SyntheticEventId
+from .model import DateOrDatetime, Event, EventStatusEnum, SyntheticEventId
 
 __all__ = ["Timeline"]
+
+_LOGGER = logging.getLogger(__name__)
+
+T = TypeVar("T")
 
 
 class Timeline(SortableItemTimeline[Event]):
@@ -34,20 +40,6 @@ class Timeline(SortableItemTimeline[Event]):
 
     def __init__(self, iterable: Iterable[SortableItem[Timespan, Event]]) -> None:
         super().__init__(iterable)
-
-
-def _event_iterable(
-    iterable: list[Event], tzinfo: datetime.tzinfo
-) -> Iterable[SortableItem[Timespan, Event]]:
-    """Create a sorted iterable from the list of events."""
-
-    def sortable_items() -> Generator[SortableItem[Timespan, Event], None, None]:
-        for event in iterable:
-            if event.recurrence:
-                continue
-            yield SortableItemValue(event.timespan_of(tzinfo), event)
-
-    return SortedItemIterable(sortable_items, tzinfo)
 
 
 class RecurAdapter:
@@ -62,15 +54,11 @@ class RecurAdapter:
         """Initialize the RecurAdapter."""
         self._event = event
         self._event_duration = event.computed_duration
-        self._is_all_day = not isinstance(self._event.start.value, datetime.datetime)
 
     def get(
         self, dtstart: datetime.datetime | datetime.date
     ) -> SortableItem[Timespan, Event]:
         """Return a lazy sortable item."""
-        if self._is_all_day and isinstance(dtstart, datetime.datetime):
-            # Convert back to datetime.date if needed for the original event
-            dtstart = datetime.date.fromordinal(dtstart.toordinal())
 
         def build() -> Event:
             if not self._event.id:
@@ -92,15 +80,78 @@ class RecurAdapter:
         )
 
 
+class AllDayConverter(Iterable[Union[datetime.date, datetime.datetime]]):
+    """An iterable that converts datetimes to all days events."""
+
+    def __init__(self, dt_iter: Iterable[datetime.date | datetime.datetime]):
+        """Initialize AllDayConverter."""
+        self._dt_iter = dt_iter
+
+    def __iter__(self) -> Iterator[datetime.date | datetime.datetime]:
+        """Return an iterator with all day events converted."""
+        for value in self._dt_iter:
+            # Convert back to datetime.date if needed for the original event
+            yield datetime.date.fromordinal(value.toordinal())
+
+
+class FilteredIterable(Iterable[T]):
+    """An iterable that excludes emits values except those excluded."""
+
+    def __init__(self, func: Iterable[T], exclude: set[T] | None) -> None:
+        self._func = func
+        self._exclude = exclude
+
+    def __iter__(self) -> Iterator[T]:
+        """Return an iterator filtered by the exclusion set."""
+        for value in self._func:
+            if self._exclude is not None and value in self._exclude:
+                continue
+            yield value
+
+
 def calendar_timeline(
     events: list[Event], tzinfo: datetime.tzinfo = datetime.timezone.utc
 ) -> Timeline:
     """Create a timeline for events on a calendar, including recurrence."""
-    iters: list[Iterable[SortableItem[Timespan, Event]]] = [
-        _event_iterable(events, tzinfo=tzinfo)
-    ]
-    for event in events:
-        if not event.recurrence:
+    normal_events: list[Event] = []
+    recurring: list[Event] = []
+    recurring_skip: dict[str, set[datetime.date | datetime.datetime]] = {}
+    for data in events:
+        event = Event.parse_obj(data)
+        if event.recurring_event_id and event.original_start_time:
+            # The API returned a one-off instance of a recurring event. Keep track
+            # of the original start time which is used to filter out from the
+            # recurrence. The one-off is handled below.
+            if event.recurring_event_id in recurring_skip:
+                recurring_skip[event.recurring_event_id].add(
+                    event.original_start_time.value
+                )
+            else:
+                recurring_skip[event.recurring_event_id] = set(
+                    [event.original_start_time.value]
+                )
+
+        if event.status == EventStatusEnum.CANCELLED:
             continue
-        iters.append(RecurIterable(RecurAdapter(event).get, event.rrule))
+        if event.recurrence:
+            recurring.append(event)
+        else:
+            normal_events.append(event)
+
+    def sortable_items() -> Generator[SortableItem[Timespan, Event], None, None]:
+        nonlocal normal_events
+        for event in normal_events:
+            if event.status == EventStatusEnum.CANCELLED:
+                continue
+            yield SortableItemValue(event.timespan_of(tzinfo), event)
+
+    iters: list[Iterable[SortableItem[Timespan, Event]]] = []
+    iters.append(SortedItemIterable(sortable_items, tzinfo))
+    for event in recurring:
+        value_iter: Iterable[datetime.date | datetime.datetime] = event.rrule
+        if not isinstance(event.start.value, datetime.datetime):
+            value_iter = AllDayConverter(value_iter)
+        value_iter = FilteredIterable(value_iter, recurring_skip.get(event.id or ""))
+        iters.append(RecurIterable(RecurAdapter(event).get, value_iter))
+
     return Timeline(MergedIterable(iters))

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -653,3 +653,117 @@ def test_missing_event_id() -> None:
 
     with pytest.raises(ValueError, match="Expected event to have event id"):
         next(timeline_iter)
+
+
+def test_modified_recurrence() -> None:
+    """Test a recurring event that was modified with a separate event from the API."""
+    events = [
+        Event.parse_obj(
+            {
+                "id": "event-id",
+                "summary": "Summary",
+                "start": {
+                    "dateTime": "2022-06-26T16:00:00-07:00",
+                    "timeZone": "America/Los_Angeles",
+                },
+                "end": {
+                    "dateTime": "2022-06-26T19:30:00-07:00",
+                    "timeZone": "America/Los_Angeles",
+                },
+                "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=SU;COUNT=20"],
+                "iCalUID": "event-id@google.com",
+                "sequence": 1,
+            }
+        ),
+        # Second event was originally in the series above, modified to be 2 hours earlier
+        Event.parse_obj(
+            {
+                "id": "event-id_20221030T230000Z",
+                "summary": "Summary",
+                "start": {
+                    "dateTime": "2022-10-30T14:00:00-07:00",
+                    "timeZone": "America/Los_Angeles",
+                },
+                "end": {
+                    "dateTime": "2022-10-30T17:30:00-07:00",
+                    "timeZone": "America/Los_Angeles",
+                },
+                "recurringEventId": "event-id",
+                "originalStartTime": {
+                    "dateTime": "2022-10-30T16:00:00-07:00",
+                    "timeZone": "America/Los_Angeles",
+                },
+                "iCalUID": "event-id@google.com",
+                "sequence": 2,
+            }
+        ),
+    ]
+
+    timeline = calendar_timeline(events)
+    assert len(list(timeline)) == 20
+    assert len(list(timeline)) == 20  # Ensure operation is repeatable
+
+    events = list(
+        timeline.overlapping(
+            datetime.date(2022, 10, 29),
+            datetime.date(2022, 10, 31),
+        )
+    )
+    assert len(events) == 1
+
+
+def test_cancelled_recurrence_instancee() -> None:
+    """Test a recurring event with a single instance that was cancelled from the API."""
+    events = [
+        Event.parse_obj(
+            {
+                "id": "event-id",
+                "summary": "Summary",
+                "start": {
+                    "date": "2022-10-30",
+                },
+                "end": {
+                    "date": "2022-10-31",
+                },
+                "recurrence": [
+                    "RRULE:FREQ=WEEKLY;WKST=SU;BYDAY=SU;COUNT=20",
+                ],
+                "iCalUID": "event-id@google.com",
+                "sequence": 0,
+            }
+        ),
+        # Second event was originally in the series above and was cancelled
+        Event.parse_obj(
+            {
+                "id": "event-id_20221030",
+                "status": "cancelled",
+                "recurringEventId": "event-id",
+                "originalStartTime": {
+                    "date": "2022-10-30",
+                },
+            }
+        ),
+    ]
+
+    timeline = calendar_timeline(events)
+    assert len(list(timeline)) == 19
+    assert len(list(timeline)) == 19  # ensure operation is repeatable
+
+    events = list(
+        timeline.overlapping(
+            datetime.date(2022, 10, 29),
+            datetime.date(2022, 11, 7),
+        )
+    )
+
+    assert len(events) == 1
+    assert events[0].start.value == datetime.date(2022, 11, 6)
+
+    # Ensure the operation is repeatable
+    events = list(
+        timeline.overlapping(
+            datetime.date(2022, 10, 29),
+            datetime.date(2022, 11, 7),
+        )
+    )
+    assert len(events) == 1

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -743,11 +743,21 @@ def test_cancelled_recurrence_instancee() -> None:
                 },
             }
         ),
+        Event.parse_obj(
+            {
+                "id": "event-id_2022113",
+                "status": "cancelled",
+                "recurringEventId": "event-id",
+                "originalStartTime": {
+                    "date": "2022-11-13",
+                },
+            }
+        ),
     ]
 
     timeline = calendar_timeline(events)
-    assert len(list(timeline)) == 19
-    assert len(list(timeline)) == 19  # ensure operation is repeatable
+    assert len(list(timeline)) == 18
+    assert len(list(timeline)) == 18  # ensure operation is repeatable
 
     events = list(
         timeline.overlapping(


### PR DESCRIPTION
Fix bug where recurring events that were cancelled or modified were not being correctly filtered from the local store. This requires changing around how cancelled events are tracked and keeping track of one-off events with modifications and the original start time to filter out from the timeline. The updated events are treated as singleton events, while the recurring event set is filtered.