### PR TITLE
Replace unknown rrule parameters to fix dateutil parse error

### DIFF
--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -339,6 +339,20 @@ def test_today(calendar_times: Timeline) -> None:
                 ),
             ],
         ),
+        (
+            datetime.date(2022, 8, 1),
+            datetime.date(2022, 8, 2),
+            [
+                "RRULE;X-EVOLUTION-ENDDATE=20220806T200000Z:FREQ=DAILY;COUNT=5",
+            ],
+            [
+                (datetime.date(2022, 8, 1), datetime.date(2022, 8, 2)),
+                (datetime.date(2022, 8, 2), datetime.date(2022, 8, 3)),
+                (datetime.date(2022, 8, 3), datetime.date(2022, 8, 4)),
+                (datetime.date(2022, 8, 4), datetime.date(2022, 8, 5)),
+                (datetime.date(2022, 8, 5), datetime.date(2022, 8, 6)),
+            ],
+        ),
     ],
 )
 def test_day_iteration(


### PR DESCRIPTION
Replace unknown rrule parameters to fix dateutil parse error for an rrule string like:

`RRULE;X-EVOLUTION-ENDDATE=20221122T200000Z:FREQ=DAILY;COUNT=30`

This is a  valid rrule, however `dateutil.rrule` does not understand unknown parameters. These issues are discussed in a few places e.g. https://github.com/dateutil/dateutil/issues/872 and https://github.com/dateutil/dateutil/issues/853

This was reported in https://github.com/home-assistant/core/issues/81409 for Home Assistant using `gcal_sync`.
