### PR TITLE
Use correct response object for Calendar 'get' calls

### DIFF
--- a/gcal_sync/api.py
+++ b/gcal_sync/api.py
@@ -30,7 +30,14 @@ from pydantic import BaseModel, Field, ValidationError, root_validator, validato
 from .auth import AbstractAuth
 from .const import ITEMS
 from .exceptions import ApiException
-from .model import EVENT_FIELDS, Calendar, Event, EventStatusEnum, SyntheticEventId
+from .model import (
+    EVENT_FIELDS,
+    Calendar,
+    CalendarBasic,
+    Event,
+    EventStatusEnum,
+    SyntheticEventId,
+)
 from .store import CalendarStore
 from .timeline import Timeline, calendar_timeline
 
@@ -322,12 +329,12 @@ class GoogleCalendarService:
         result = await self._auth.get_json(CALENDAR_LIST_URL, params=params)
         return CalendarListResponse.parse_obj(result)
 
-    async def async_get_calendar(self, calendar_id: str) -> Calendar:
+    async def async_get_calendar(self, calendar_id: str) -> CalendarBasic:
         """Return the calendar with the specified id."""
         result = await self._auth.get_json(
             CALENDAR_GET_URL.format(calendar_id=calendar_id)
         )
-        return Calendar.parse_obj(result)
+        return CalendarBasic.parse_obj(result)
 
     async def async_get_event(self, calendar_id: str, event_id: str) -> Event:
         """Return an event based on the event id."""

--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -33,6 +33,7 @@ __all__ = [
     "ResponseStatus",
     "Attendee",
     "AccessRole",
+    "CalendarBasic",
 ]
 
 _LOGGER = logging.getLogger(__name__)
@@ -68,7 +69,7 @@ class AccessRole(str, Enum):
 
 
 class Calendar(BaseModel):
-    """Metadata associated with a calendar."""
+    """Metadata associated with a calendar from the CalendarList API."""
 
     id: str
     """Identifier of the calendar."""
@@ -93,6 +94,30 @@ class Calendar(BaseModel):
 
     primary: bool = False
     """Whether the calendar is the primary calendar of the authenticated user."""
+
+    class Config:
+        """Pydnatic model configuration."""
+
+        allow_population_by_field_name = True
+
+
+class CalendarBasic(BaseModel):
+    """Metadata associated with a calendar from the Get API."""
+
+    id: str
+    """Identifier of the calendar."""
+
+    summary: str = ""
+    """Title of the calendar."""
+
+    description: Optional[str]
+    """Description of the calendar."""
+
+    location: Optional[str]
+    """Geographic location of the calendar as free-form text."""
+
+    timezone: Optional[str] = Field(alias="timeZone", default=None)
+    """The time zone of the calendar."""
 
     class Config:
         """Pydnatic model configuration."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,14 @@ from gcal_sync.api import (
     LocalListEventsRequest,
     Range,
 )
-from gcal_sync.model import EVENT_FIELDS, AccessRole, Calendar, DateOrDatetime, Event
+from gcal_sync.model import (
+    EVENT_FIELDS,
+    AccessRole,
+    Calendar,
+    CalendarBasic,
+    DateOrDatetime,
+    Event,
+)
 from gcal_sync.sync import CalendarEventSyncManager
 
 from .conftest import ApiRequest, ApiResult
@@ -37,13 +44,13 @@ async def test_get_calendar(
         {
             "id": "calendar-id-1",
             "summary": "Calendar 1",
-            "accessRole": "writer",
         },
     )
     calendar_service = await calendar_service_cb()
     result = await calendar_service.async_get_calendar("primary")
-    assert result == Calendar(
-        id="calendar-id-1", summary="Calendar 1", access_role=AccessRole.WRITER
+    assert result == CalendarBasic(
+        id="calendar-id-1",
+        summary="Calendar 1",
     )
 
     assert url_request() == ["/calendars/primary"]


### PR DESCRIPTION
Use correct response object for Calendar 'get' calls that return less information than `CalendarList` calls.