### PR TITLE
Use existing date time for unknown timezones returned from API

### DIFF
--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -159,11 +159,14 @@ class DateOrDatetime(BaseModel):
                 # Always use the timezone when there isn't one, otherwise only override when
                 # using to start recurring events. Otherwise, just use the simple offset
                 # specified in the event.
+                try:
+                    use_tzinfo = zoneinfo.ZoneInfo(self.timezone)
+                except zoneinfo.ZoneInfoNotFoundError:
+                    _LOGGER.debug("Timezone '%s' not found; ignoring", self.timezone)
+                    return self.date_time
                 if self.date_time.tzinfo is None:
-                    return self.date_time.replace(
-                        tzinfo=zoneinfo.ZoneInfo(self.timezone)
-                    )
-                return self.date_time.astimezone(tz=zoneinfo.ZoneInfo(self.timezone))
+                    return self.date_time.replace(tzinfo=use_tzinfo)
+                return self.date_time.astimezone(tz=use_tzinfo)
             return self.date_time
         raise ValueError("Datetime has invalid state with no date or date_time")
 

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -890,3 +890,33 @@ def test_rdate_params() -> None:
         )
     )
     assert len(events) == 2
+
+
+def test_unknown_timezone() -> None:
+    """Test timezone evaluation when the timezone returned from the API is not known."""
+
+    event = Event.parse_obj(
+        {
+            "id": "event-id",
+            "summary": "Summary",
+            "start": {
+                "date_time": "2022-11-12T10:00:00",
+                "timezone": "GMT+02:00",
+            },
+            "end": {
+                "date_time": "2022-11-12T11:00:00",
+                "timezone": "GMT+02:00",
+            },
+        }
+    )
+
+    timeline = calendar_timeline([event], zoneinfo.ZoneInfo("UTC"))
+    events = list(
+        timeline.overlapping(
+            datetime.date(2022, 11, 1),
+            datetime.date(2022, 11, 30),
+        )
+    )
+    assert len(events) == 1
+    assert events[0].start.value == datetime.datetime(2022, 11, 12, 10, 00)
+    assert events[0].end.value == datetime.datetime(2022, 11, 12, 11, 00)


### PR DESCRIPTION
When the timezone is not known, just use the timezone present in the existing time. This may be a local floating time or a time with an offset.

Note: This may introduce issues with recurring events.

Issue: https://github.com/home-assistant/core/issues/81917