### PR TITLE
Fix TypeError bug in RDATE all day event handling

### DIFF
--- a/gcal_sync/timeline.py
+++ b/gcal_sync/timeline.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import datetime
 import logging
 from collections.abc import Generator, Iterable, Iterator
-from typing import TypeVar, Union
+from typing import TypeVar
 
 from ical.iter import (
     LazySortableItem,
@@ -80,20 +80,6 @@ class RecurAdapter:
         )
 
 
-class AllDayConverter(Iterable[Union[datetime.date, datetime.datetime]]):
-    """An iterable that converts datetimes to all days events."""
-
-    def __init__(self, dt_iter: Iterable[datetime.date | datetime.datetime]):
-        """Initialize AllDayConverter."""
-        self._dt_iter = dt_iter
-
-    def __iter__(self) -> Iterator[datetime.date | datetime.datetime]:
-        """Return an iterator with all day events converted."""
-        for value in self._dt_iter:
-            # Convert back to datetime.date if needed for the original event
-            yield datetime.date.fromordinal(value.toordinal())
-
-
 class FilteredIterable(Iterable[T]):
     """An iterable that excludes emits values except those excluded."""
 
@@ -149,8 +135,6 @@ def calendar_timeline(
     iters.append(SortedItemIterable(sortable_items, tzinfo))
     for event in recurring:
         value_iter: Iterable[datetime.date | datetime.datetime] = event.rrule
-        if not isinstance(event.start.value, datetime.datetime):
-            value_iter = AllDayConverter(value_iter)
         value_iter = FilteredIterable(value_iter, recurring_skip.get(event.id or ""))
         iters.append(RecurIterable(RecurAdapter(event).get, value_iter))
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -322,7 +322,7 @@ def test_event_timezone_comparison() -> None:
     assert not event1.includes(event2)
 
 
-def test_event_timezone_comparison_zimetone_not_used() -> None:
+def test_event_timezone_comparison_timetone_not_used() -> None:
     """Compare different ways the same time can be returned."""
 
     event1 = Event.parse_obj(
@@ -721,3 +721,30 @@ def test_invalid_event_id(event_id: str) -> None:
 def test_access_role_writer(access_role: AccessRole, writer: bool) -> None:
     """Test that access roles are writers."""
     assert access_role.is_writer == writer
+
+
+def test_event_timezone_with_offset() -> None:
+    """Verify the time parsing for a timezone and a date time with an offset."""
+
+    event = Event.parse_obj(
+        {
+            "id": "some-event-id",
+            "summary": "Event #1",
+            "start": {
+                "dateTime": "2022-11-24T19:45:00+01:00",
+                "timeZone": "Europe/Rome",
+            },
+            "end": {
+                "dateTime": "2022-11-24T20:00:00+01:00",
+                "timeZone": "Europe/Rome",
+            },
+        }
+    )
+    assert event.start.date is None
+    assert event.start.date_time == datetime.datetime(
+        2022, 11, 24, 19, 45, tzinfo=zoneinfo.ZoneInfo("Europe/Rome")
+    )
+    assert event.start.value == datetime.datetime(
+        2022, 11, 24, 19, 45, tzinfo=zoneinfo.ZoneInfo("Europe/Rome")
+    )
+    assert event.start.value.isoformat() == "2022-11-24T19:45:00+01:00"


### PR DESCRIPTION
Fix bug in RDATE all day event handling:
```
tests/test_timeline.py:916: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../ical/ical/iter.py:234: in overlapping
    for item in self._iterable:
../ical/ical/iter.py:143: in __next__
    self._make_heap()
../ical/ical/iter.py:133: in _make_heap
    next_item = next(iterator)
../ical/ical/iter.py:113: in __iter__
    for dtvalue in self._recur:
gcal_sync/timeline.py:106: in __iter__
    for value in self._func:
gcal_sync/timeline.py:92: in __iter__
    for value in self._dt_iter:
../ical/ical/iter.py:113: in __iter__
    for dtvalue in self._recur:
venv/lib/python3.9/site-packages/dateutil/rrule.py:1396: in _iter
    heapq.heapify(rlist)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <dateutil.rrule.rruleset._genitem object at 0x7f484cc22b50>
other = <dateutil.rrule.rruleset._genitem object at 0x7f484cc221c0>

    def __lt__(self, other):
>       return self.dt < other.dt
E       TypeError: can't compare datetime.datetime to datetime.date

venv/lib/python3.9/site-packages/dateutil/rrule.py:1338: TypeError
```

The approach is to simplify the date vs datetime workaround that already exists, due to limitations in `dateutil.rrule` when used in a `dateutil.ruleset`.