### PR TITLE
Bump ical and use new RecurrenceIterable for improved debug

### DIFF
--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 import datetime
 import logging
 import zoneinfo
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable
 from enum import Enum
 from typing import Any, Optional, Union
 
-from dateutil import rrule
 from ical.component import ComponentModel
+from ical.iter import RulesetIterable
 from ical.parsing.component import parse_content
 from ical.timespan import Timespan
 from ical.types.data_types import DATA_TYPE
@@ -353,20 +353,6 @@ class SyntheticEventId:
         return self._dtstart
 
 
-class AllDayConverter(Iterable[Union[datetime.date, datetime.datetime]]):
-    """An iterable that converts datetimes to all days events."""
-
-    def __init__(self, dt_iter: Iterable[datetime.date | datetime.datetime]):
-        """Initialize AllDayConverter."""
-        self._dt_iter = dt_iter
-
-    def __iter__(self) -> Iterator[datetime.date | datetime.datetime]:
-        """Return an iterator with all day events converted."""
-        for value in self._dt_iter:
-            # Convert back to datetime.date if needed for the original event
-            yield datetime.date.fromordinal(value.toordinal())
-
-
 class Recurrence(ComponentModel):
     """A pydantic model that captures the objects in a Google Calendar recurrence."""
 
@@ -421,26 +407,12 @@ class Recurrence(ComponentModel):
         self, dtstart: datetime.date | datetime.datetime
     ) -> Iterable[datetime.date | datetime.datetime]:
         """Return the set of recurrences as a rrule that emits start times."""
-
-        is_date: bool = not isinstance(dtstart, datetime.datetime)
-
-        ruleset = rrule.rruleset()
-        for rule in self.rrule:
-            # dateutil.rrule will convert all input values to datetime even if the
-            # input value is a date. If needed, convert back to a date so that
-            # comparisons between exdate/rdate as a date in the rruleset will
-            # be in the right format.
-            value_iter: Iterable[datetime.date | datetime.datetime] = rule.as_rrule(
-                dtstart
-            )
-            if is_date:
-                value_iter = AllDayConverter(value_iter)
-            ruleset.rrule(value_iter)  # type: ignore[arg-type]
-        for rdate in self.rdate:
-            ruleset.rdate(rdate)  # type: ignore[no-untyped-call]
-        for exdate in self.exdate:
-            ruleset.exdate(exdate)  # type: ignore[no-untyped-call]
-        return ruleset
+        return RulesetIterable(
+            dtstart,
+            [rule.as_rrule(dtstart) for rule in self.rrule],
+            self.rdate,
+            self.exdate,
+        )
 
     def as_recurrence(self) -> list[str]:
         """Serialize the recurrence rule as an API string."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ coverage==6.5.0
 flake8-black==0.3.5
 flake8==5.0.4
 freezegun==1.2.2
-ical==4.1.1
+ical==4.2.0
 mypy==0.991
 pdoc==12.3.0
 pre-commit==2.20.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ python_requires = >= 3.9
 install_requires =
   aiohttp>=3.8.1
   pydantic>=1.9.0
-  ical>=4.1.1
+  ical>=4.2.0
 include_package_data = True
 package_dir =
     = .


### PR DESCRIPTION
Bump ical and use new `RecurrenceIterable` for improved debug support. The new iter wraps `dateutil.ruleset` and contains all the helpers for converting back/forth for all day events since `dateutil.rrule` only supports `datetime.datetime` iteration. Additionally, this should help with extra debugging information to diagnose issues like this where the rruleset is comparing dates and times of different types:

```
  File "/usr/local/lib/python3.10/site-packages/gcal_sync/timeline.py", line 106, in __iter__
    for value in self._func:
  File "/usr/local/lib/python3.10/site-packages/gcal_sync/timeline.py", line 92, in __iter__
    for value in self._dt_iter:
  File "/usr/local/lib/python3.10/site-packages/ical/iter.py", line 113, in __iter__
    for dtvalue in self._recur:
  File "/usr/local/lib/python3.10/site-packages/dateutil/rrule.py", line 1396, in _iter
    heapq.heapify(rlist)
  File "/usr/local/lib/python3.10/site-packages/dateutil/rrule.py", line 1338, in __lt__
    return self.dt < other.dt
TypeError: can't compare datetime.datetime to datetime.date
```