### PR TITLE
Add an exception to be able to detect disabled API

### DIFF
--- a/gcal_sync/exceptions.py
+++ b/gcal_sync/exceptions.py
@@ -15,3 +15,7 @@ class AuthException(ApiException):
 
 class InvalidSyncTokenException(ApiException):
     """Raised when the sync token is invalid."""
+
+
+class ApiForbiddenException(ApiException):
+    """Raised due to permission errors talking to API."""


### PR DESCRIPTION
Add an exception to be able to detect disabled API based on the response code.

Today the error message is something like this:
```
Error from API: 403: PERMISSION_DENIED: Google Calendar API has not been used in project XXXXXX before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/calendar-json.googleapis.com/overview?project=YYYYYYYY then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.: Forbidden
```