### PR TITLE
Adjust BYMONTHDAY Google Calendar RRULEs to limit expansion

### DIFF
--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1041,3 +1041,24 @@ def test_unknown_timezone() -> None:
     assert len(events) == 1
     assert events[0].start.value == datetime.datetime(2022, 11, 12, 10, 00)
     assert events[0].end.value == datetime.datetime(2022, 11, 12, 11, 00)
+
+
+def test_yearly_bymonthday_rrule() -> None:
+    """Test FREQ=YEARLY rules returned from the API with BYMONTHDAY rules."""
+    event = Event.parse_obj(
+        {
+            "id": "some-event-id",
+            "summary": "Summary",
+            "start": {"date": "2022-09-07"},
+            "end": {
+                "date": "2022-09-08",
+            },
+            "recurrence": ["RRULE:FREQ=YEARLY;BYMONTHDAY=7;COUNT=3"],
+        }
+    )
+    timeline = calendar_timeline([event])
+    assert [e.start.value.isoformat() for e in timeline] == [
+        "2022-09-07",
+        "2023-09-07",
+        "2024-09-07",
+    ]


### PR DESCRIPTION
Adjust `BYMONTHDAY` Google Calendar RRULEs to limit expansion by adding a `BYMONTH` rule for `FREQ=YEARLY` rules. These are currently interpreted differently by Google than by `dateutil.rrule`, so the fix is to adjust the API response when building the recurrence object.

See discussion in https://stackoverflow.com/questions/43084211/icalendar-yearly-rrule-without-bymonth-value