### PR TITLE
Improve pydantic model defaults

### DIFF
--- a/gcal_sync/api.py
+++ b/gcal_sync/api.py
@@ -452,7 +452,7 @@ class LocalListEventsRequest(BaseModel):
 class LocalListEventsResponse(BaseModel):
     """Api response containing a list of events."""
 
-    events: List[Event] = Field(default=[])
+    events: List[Event] = Field(default_factory=list)
     """Events returned from the local store."""
 
 

--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -76,10 +76,10 @@ class Calendar(BaseModel):
     summary: str = ""
     """Title of the calendar."""
 
-    description: Optional[str]
+    description: Optional[str] = None
     """Description of the calendar."""
 
-    location: Optional[str]
+    location: Optional[str] = None
     """Geographic location of the calendar as free-form text."""
 
     timezone: Optional[str] = Field(alias="timeZone", default=None)
@@ -109,10 +109,10 @@ class CalendarBasic(BaseModel):
     summary: str = ""
     """Title of the calendar."""
 
-    description: Optional[str]
+    description: Optional[str] = None
     """Description of the calendar."""
 
-    location: Optional[str]
+    location: Optional[str] = None
     """Geographic location of the calendar as free-form text."""
 
     timezone: Optional[str] = Field(alias="timeZone", default=None)
@@ -449,10 +449,10 @@ class Event(BaseModel):
     end: DateOrDatetime
     """The (exclusive) end time of the event."""
 
-    description: Optional[str]
+    description: Optional[str] = None
     """Description of the event, which can contain HTML."""
 
-    location: Optional[str]
+    location: Optional[str] = None
     """Geographic location of the event as free-form text."""
 
     transparency: str = Field(default="opaque")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ ical==4.2.9
 mypy==0.991
 pdoc==12.3.1
 pre-commit==3.1.1
-pydantic==1.10.5
+pydantic==1.10.6
 pylint==2.16.4
 pytest==7.2.2
 pytest-aiohttp==1.0.4


### PR DESCRIPTION
* Make `Optional[...]` defaults explicits. This will be required in pydantic `v2` anyway.
* Use `default_factory` for list default.
* Update pinned `pydantic` version to `1.10.6`
https://github.com/pydantic/pydantic/releases/tag/v1.10.6
-> Resolves issues with mypy `1.1.1`, so #190 should work after this is merged