### PR TITLE
Coerce invalid all day events to have a valid duration

### DIFF
--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -537,6 +537,22 @@ class Event(BaseModel):
         return values
 
     @root_validator
+    def _adjust_duration(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Fix events with invalid durations."""
+        _LOGGER.debug("_adjust_duration")
+        if (
+            (dtstart := values.get("start"))
+            and (dtend := values.get("end"))
+            and dtstart.date
+            and dtend.date
+            and ((dtend.date - dtstart.date) <= datetime.timedelta(days=0))
+        ):
+            # Duration is zero or negative. Default to 1 day
+            dtend.date = dtstart.date + datetime.timedelta(days=1)
+            values["end"] = dtend
+        return values
+
+    @root_validator
     def _validate_rrule(cls, values: dict[str, Any]) -> dict[str, Any]:
         """The API returns invalid RRULEs that need to be coerced to valid."""
         # Rules may need updating of start time has a timezone

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -748,3 +748,25 @@ def test_event_timezone_with_offset() -> None:
         2022, 11, 24, 19, 45, tzinfo=zoneinfo.ZoneInfo("Europe/Rome")
     )
     assert event.start.value.isoformat() == "2022-11-24T19:45:00+01:00"
+
+
+def test_all_day_event() -> None:
+    """Verify that all day events with invalid durations are fixed."""
+
+    event = Event.parse_obj(
+        {
+            "id": "some-event-id",
+            "summary": "Event #1",
+            "start": {
+                "date": "2022-11-24",
+            },
+            "end": {
+                "date": "2022-11-24",  # Invalid end date
+            },
+        }
+    )
+    assert event.timespan.duration == datetime.timedelta(days=1)
+    assert event.start.date == datetime.date(2022, 11, 24)
+    assert event.start.value.isoformat() == "2022-11-24"
+    assert event.end.date == datetime.date(2022, 11, 25)
+    assert event.end.value.isoformat() == "2022-11-25"


### PR DESCRIPTION
Update invalid events parsed from the response to have valid durations. Google calendar may return an all day event with a zero duration, which is not expected.