### PR TITLE
Prevent dependencies on newer versions of pydantic

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ packages = find:
 python_requires = >= 3.9
 install_requires =
   aiohttp>=3.8.1
-  pydantic>=1.9.0
+  pydantic>=1.9.0,<2.0a
   ical>=4.2.5
 include_package_data = True
 package_dir =


### PR DESCRIPTION
Requires a large overhaul: https://docs.pydantic.dev/blog/pydantic-v2-alpha/