### PR TITLE
Ensure that all returned datetime based events have valid durations

### DIFF
--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -539,17 +539,17 @@ class Event(BaseModel):
     @root_validator
     def _adjust_duration(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Fix events with invalid durations."""
-        _LOGGER.debug("_adjust_duration")
         if (
             (dtstart := values.get("start"))
             and (dtend := values.get("end"))
-            and dtstart.date
-            and dtend.date
-            and ((dtend.date - dtstart.date) <= datetime.timedelta(days=0))
+            and (dtend.value - dtstart.value) <= datetime.timedelta(seconds=0)
         ):
-            # Duration is zero or negative. Default to 1 day
-            dtend.date = dtstart.date + datetime.timedelta(days=1)
-            values["end"] = dtend
+            if dtstart.date and dtend.date:
+                dtend.date = dtstart.date + datetime.timedelta(days=1)
+                values["end"] = dtend
+            if dtstart.date_time and dtend.date_time:
+                dtend.date_time = dtstart.date_time + datetime.timedelta(minutes=30)
+                values["end"] = dtend
         return values
 
     @root_validator

--- a/run-mypy
+++ b/run-mypy
@@ -5,6 +5,6 @@ set -o errexit
 # Change directory to the project root directory.
 cd "$(dirname "$0")"
 
-pip3 install -r requirements.txt --no-input
+pip3 install -r requirements.txt --no-input --quiet
 
 mypy .

--- a/run-mypy
+++ b/run-mypy
@@ -5,6 +5,6 @@ set -o errexit
 # Change directory to the project root directory.
 cd "$(dirname "$0")"
 
-pip3 install -r requirements.txt --no-input --quiet
+pip3 install -r requirements.txt --no-input
 
 mypy .


### PR DESCRIPTION
This is similar to the update in #225 but for events with a time.