### PR TITLE
Update Reminder.Use_Default to True

### DIFF
--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -453,7 +453,7 @@ class ReminderOverride(BaseModel):
 class Reminders(BaseModel):
     """Information about the event's reminders for the authenticated user."""
 
-    use_default: bool = Field(alias="useDefault", default=False)
+    use_default: bool = Field(alias="useDefault", default=True)
 
     overrides: list[ReminderOverride] = Field(default_factory=list)
     """Reminders to use instead of the default reminders.


### PR DESCRIPTION
Fixing residual issue with #239. Google requires that when sending `reminders overrides` to set Use_Default = False. Meaning we need the inverted as the default.