### PR TITLE
Fix for invalid RRULES returned by the Google calendar API

### DIFF
--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -577,6 +577,19 @@ class Event(BaseModel):
         return values
 
     @root_validator(pre=True)
+    def _adjust_invalid_recurrence_rules(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Fix invalid rrule parameters not supported by dateutil.rrule."""
+        if not (recurrence_values := values.get("recurrence")):
+            return values
+        updated = []
+        for recurrence_value in recurrence_values:
+            if recurrence_value.startswith("DATE;"):
+                recurrence_value = recurrence_value.replace("DATE;", "RDATE;")
+            updated.append(recurrence_value)
+        values["recurrence"] = updated
+        return values
+
+    @root_validator(pre=True)
     def _validate_recur(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Remove rrule property parameters not supported by dateutil.rrule."""
         if not values.get("recurrence"):

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -606,6 +606,32 @@ def test_invalid_rrule_until_local_datetime() -> None:
     ]
 
 
+def test_invalid_rrule_until_spurios_date() -> None:
+    """Test recurrence rule with mismatched UNTIL value from google api."""
+    event = Event.parse_obj(
+        {
+            "id": "event-id",
+            "summary": "Summary",
+            "start": {"date": "2023-08-02"},
+            "end": {"date": "2023-08-01"},
+            "recurrence": [
+                "DATE;TZID=Europe/Warsaw:20230818T020000,20230915T020000,20231013T020000,20231110T010000,20231208T010000"
+            ],
+        }
+    )
+    timeline = calendar_timeline([event])
+    assert [(e.start.value, e.end.value) for e in islice(timeline, 6)] == [
+        (datetime.date(2023, 8, 18), datetime.date(2023, 8, 19)),
+        (datetime.date(2023, 9, 15), datetime.date(2023, 9, 16)),
+        (datetime.date(2023, 10, 13), datetime.date(2023, 10, 14)),
+        (datetime.date(2023, 11, 10), datetime.date(2023, 11, 11)),
+        (datetime.date(2023, 12, 8), datetime.date(2023, 12, 9)),
+    ]
+    assert event.recurrence == [
+        "RDATE;TZID=Europe/Warsaw:20230818T020000,20230915T020000,20231013T020000,20231110T010000,20231208T010000"
+    ]
+
+
 @pytest.mark.parametrize(
     "time_zone,event_order",
     [


### PR DESCRIPTION
Apply a fix for invalid RRULES returned by the Google calendar API

Example invalid rule:
> DATE;TZID=Europe/Warsaw:20230818T020000,20230915T020000,20231013T020000,20231110T010000,20231208T010000
