### PR TITLE
Fix for invalid parsing of attendees

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gcal-sync
-version = 6.0.1
+version = 6.0.2
 description = A python library for syncing Google Calendar to local storage
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -469,12 +469,19 @@ def test_attendees() -> None:
             "end": {
                 "date": "2022-04-13",
             },
+            "creator": {
+                "id": "creator-1",
+                "email": "example0@example.com",
+                "displayName": "Example 0",
+                "self": "False",
+            },
             "attendees": [
                 {
                     "id": "attendee-id-1",
                     "email": "example1@example.com",
                     "displayName": "Example 1",
                     "comment": "comment 1",
+                    "self": True,
                 },
                 {
                     "id": "attendee-id-2",


### PR DESCRIPTION
Fix for invalid parsing of attendees due to the `self` keyword being a python reserved word.

This is a follow on fix for #354