### PR TITLE
Add working location event type

### DIFF
--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -264,6 +264,9 @@ class EventTypeEnum(str, Enum):
     FOCUS_TIME = "focusTime"
     """A focus-time event."""
 
+    WORKING_LOCATION = "workingLocation"
+    """An event at a specific location."""
+
 
 class VisibilityEnum(str, Enum):
     """Visibility of the event."""


### PR DESCRIPTION
Before this PR, the code does not allow the `workingLocation` option for the event type. This causes a corporate calendar that someone may be using in Home Assistant to not function.

My error is shown below:

```
Logger: homeassistant.components.google.calendar
Source: helpers/update_coordinator.py:350
integration: Google Calendar (documentation, issues)
First occurred: 12:32:36 (1 occurrences)
Last logged: 12:32:36

Error fetching *** data: Error communicating with API: Failed to parse component: 1 validation error for Event eventType value is not a valid enumeration member; permitted: 'default', 'outOfOffice', 'focusTime' (type=type_error.enum; enum_values=[<EventTypeEnum.DEFAULT: 'default'>, <EventTypeEnum.OUT_OF_OFFICE: 'outOfOffice'>, <EventTypeEnum.FOCUS_TIME: 'focusTime'>])
```


https://developers.google.com/calendar/api/guides/calendar-status