### PR TITLE
Handle unknown event types with fallback value

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gcal_sync
-version = 6.1.5
+version = 6.1.6
 description = A python library for syncing Google Calendar to local storage
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -405,6 +405,8 @@ def test_required_fields() -> None:
         ("outOfOffice", EventTypeEnum.OUT_OF_OFFICE),
         ("workingLocation", EventTypeEnum.WORKING_LOCATION),
         ("fromGmail", EventTypeEnum.FROM_GMAIL),
+        ("birthday", EventTypeEnum.BIRTHDAY),
+        ("some-event-type", EventTypeEnum.UNKNOWN),
     ],
 )
 def test_event_type(api_event_type: str, event_type: EventTypeEnum) -> None:


### PR DESCRIPTION
Add support for the new `birthday` event type and also gracefully handle new unknown event types.