### PR TITLE
Add isSelf attribute to model instead of omitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ See `gcal_sync.sync` for more details.
 ```bash
 $ python3 -m venv venv
 $ source venv/bin/activate
-$ pip3 install -r requirements.txt
+$ pip3 install -r requirements_dev.txt
 
 # Run tests
 $ py.test

--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -114,7 +114,7 @@ class CalendarBaseModel(BaseModel):
     def _remove_self(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Rename any 'self' fields from all child values of the dictionary."""
         if "self" in values:
-            values["isSelf"] = values["self"]
+            values["is_self"] = values["self"]
             del values["self"]
 
         # Mutate any children with "self" fields
@@ -343,7 +343,7 @@ class Attendee(CalendarBaseModel):
     optional: bool = False
     """Whether this is an optional attendee."""
 
-    isSelf: bool = False
+    is_self: bool = False
     """Whether this entry represents the calendar on which this copy of the event appears."""
 
     comment: Optional[str] = None

--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -114,7 +114,7 @@ class CalendarBaseModel(BaseModel):
     def _remove_self(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Rename any 'self' fields from all child values of the dictionary."""
         if "self" in values:
-            values["self_"] = values["self"]
+            values["isSelf"] = values["self"]
             del values["self"]
 
         # Mutate any children with "self" fields
@@ -342,6 +342,9 @@ class Attendee(CalendarBaseModel):
 
     optional: bool = False
     """Whether this is an optional attendee."""
+
+    isSelf: bool = False
+    """Whether this entry represents the calendar on which this copy of the event appears."""
 
     comment: Optional[str] = None
     """The attendee's response comment."""

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -509,21 +509,21 @@ def test_attendees() -> None:
             displayName="Example 1",
             comment="comment 1",
             responseStatus=ResponseStatus.NEEDS_ACTION,
-            isSelf=True,
+            is_self=True,
         ),
         Attendee(
             id="attendee-id-2",
             email="example2@example.com",
             displayName="Example 2",
             responseStatus=ResponseStatus.ACCEPTED,
-            isSelf=False,
+            is_self=False,
         ),
         Attendee(
             id="attendee-id-3",
             email="example3@example.com",
             displayName="Example 3",
             responseStatus=ResponseStatus.DECLINED,
-            isSelf=False,
+            is_self=False,
         ),
     ]
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -509,18 +509,21 @@ def test_attendees() -> None:
             displayName="Example 1",
             comment="comment 1",
             responseStatus=ResponseStatus.NEEDS_ACTION,
+            isSelf=True,
         ),
         Attendee(
             id="attendee-id-2",
             email="example2@example.com",
             displayName="Example 2",
             responseStatus=ResponseStatus.ACCEPTED,
+            isSelf=False,
         ),
         Attendee(
             id="attendee-id-3",
             email="example3@example.com",
             displayName="Example 3",
             responseStatus=ResponseStatus.DECLINED,
+            isSelf=False,
         ),
     ]
 


### PR DESCRIPTION
In support of https://github.com/home-assistant/core/pull/128900#discussion_r1808979448, this PR exposes the original value of `self` as `isSelf` instead of omitting it. 

I also updated the README to reference the `pip3 install` target correctly.