### PR TITLE
Add Attendee organizer and resource

### DIFF
--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -368,6 +368,12 @@ class Attendee(CalendarBaseModel):
     comment: Optional[str] = None
     """The attendee's response comment."""
 
+    organizer: bool = False
+    """Whether the attendee is the organizer of the event."""
+
+    resource: bool = False
+    """Whether the attendee is a resource."""
+
     response_status: ResponseStatus = Field(
         alias="responseStatus", default=ResponseStatus.NEEDS_ACTION
     )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -604,6 +604,8 @@ def test_attendees() -> None:
                     "displayName": "Example 1",
                     "comment": "comment 1",
                     "self": True,
+                    "organizer": True,
+                    "resource": True,
                 },
                 {
                     "id": "attendee-id-2",
@@ -628,6 +630,8 @@ def test_attendees() -> None:
             comment="comment 1",
             responseStatus=ResponseStatus.NEEDS_ACTION,
             is_self=True,
+            organizer=True,
+            resource=True,
         ),
         Attendee(
             id="attendee-id-2",
@@ -635,6 +639,8 @@ def test_attendees() -> None:
             displayName="Example 2",
             responseStatus=ResponseStatus.ACCEPTED,
             is_self=False,
+            organizer=False,
+            resource=False,
         ),
         Attendee(
             id="attendee-id-3",
@@ -642,6 +648,8 @@ def test_attendees() -> None:
             displayName="Example 3",
             responseStatus=ResponseStatus.DECLINED,
             is_self=False,
+            organizer=False,
+            resource=False,
         ),
     ]
 


### PR DESCRIPTION
Add boolean attributes `organizer` and `resource` to Attendee data model. They are very useful when working in meetings.

- `organizer` identify which attendee is the event's creator
- `resource` allows for easy identification and filtering of non-person attendees, such as conference rooms, projectors etc

We use this branch in production on many calendars and it works without any problems.