### PR TITLE
fix: resolve ty check v0.39 type errors and update ty to v0.0.39

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         entry: ty check . --ignore unresolved-import
         language: python
         pass_filenames: false
-        additional_dependencies: ["ty==0.0.18"]
+        additional_dependencies: ["ty==0.0.39"]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.2
     hooks:

--- a/gcal_sync/api.py
+++ b/gcal_sync/api.py
@@ -156,13 +156,15 @@ class ListEventsRequest(SyncableRequest):
         """Convert to the raw API request for sending to the API."""
         return _RawListEventsRequest(
             **json.loads(self.model_dump_json(exclude_none=True, by_alias=True)),
-            single_events=Boolean.TRUE,
-            order_by=OrderBy.START_TIME,
+            singleEvents=Boolean.TRUE,
+            orderBy=OrderBy.START_TIME,
         )
 
     @field_validator("start_time")
     @classmethod
-    def _default_start_time(cls, value: datetime.datetime | None) -> datetime.datetime:
+    def _default_start_time(
+        cls, value: datetime.datetime | None
+    ) -> datetime.datetime | None:
         """Select a default start time value of not specified."""
         if value is None:
             return now()
@@ -193,7 +195,7 @@ class SyncEventsRequest(ListEventsRequest):
 
     @field_validator("start_time")
     @classmethod
-    def _default_start_time(  # type: ignore[override]
+    def _default_start_time(
         cls, value: datetime.datetime | None
     ) -> datetime.datetime | None:
         """Disables default value behavior."""

--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -117,6 +117,24 @@ def _raise_parse_exception(
     return CalendarParseException(error_str, detailed_error=str(err))
 
 
+def _remove_self_fields(values: dict[str, Any]) -> dict[str, Any]:
+    """Rename any 'self' fields from all child values of the dictionary."""
+    if "self" in values:
+        values["is_self"] = values["self"]
+        del values["self"]
+
+    # Mutate any children with "self" fields
+    updates = {}
+    for k, v in values.items():
+        if isinstance(v, dict):
+            updates[k] = _remove_self_fields(v)
+        elif isinstance(v, list) and len(v) > 0 and isinstance(v[0], dict):
+            updates[k] = [_remove_self_fields(item) for item in v]
+    values.update(updates)
+
+    return values
+
+
 class CalendarBaseModel(BaseModel):
     """Base class for calendar models."""
 
@@ -131,20 +149,7 @@ class CalendarBaseModel(BaseModel):
     @classmethod
     def _remove_self(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Rename any 'self' fields from all child values of the dictionary."""
-        if "self" in values:
-            values["is_self"] = values["self"]
-            del values["self"]
-
-        # Mutate any children with "self" fields
-        updates = {}
-        for k, v in values.items():
-            if isinstance(v, dict):
-                updates[k] = cls._remove_self(v)  # type: ignore[operator]
-            elif isinstance(v, list) and len(v) > 0 and isinstance(v[0], dict):
-                updates[k] = [cls._remove_self(item) for item in v]  # type: ignore[operator]
-        values.update(updates)
-
-        return values
+        return _remove_self_fields(values)
 
 
 class Calendar(CalendarBaseModel):
@@ -221,7 +226,7 @@ class DateOrDatetime(CalendarBaseModel):
     def parse(cls, value: datetime.date | datetime.datetime) -> DateOrDatetime:
         """Create a DateOrDatetime from a raw date or datetime value."""
         if isinstance(value, datetime.datetime):
-            return cls(date_time=value)
+            return cls(dateTime=value)
         return cls(date=value)
 
     @property

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 -e .
 coverage==7.14.0
-ty==0.0.18
+ty==0.0.39
 pdoc==16.0.0
 pip==26.1.1
 pre-commit==4.6.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,9 +69,9 @@ async def handler(request: aiohttp.web.Request) -> aiohttp.web.Response:
 
 
 @pytest.fixture
-async def request_handler() -> (
-    Callable[[aiohttp.web.Request], Awaitable[aiohttp.web.Response]]
-):
+async def request_handler() -> Callable[
+    [aiohttp.web.Request], Awaitable[aiohttp.web.Response]
+]:
     """A fake request handler."""
     return handler
 


### PR DESCRIPTION
This PR resolves all type checker errors introduced by the newer version of the ty type checker (v0.0.39), updates ty to v0.0.39 in requirements_dev.txt and .pre-commit-config.yaml, and fully restores passing CI checks.