### PR TITLE
Add support for Event colorId and the Colors API

### DIFF
--- a/gcal_sync/api.py
+++ b/gcal_sync/api.py
@@ -36,6 +36,7 @@ from .model import (
     CalendarBaseModel,
     Calendar,
     CalendarBasic,
+    Colors,
     Event,
     EventStatusEnum,
     SyntheticEventId,
@@ -68,6 +69,7 @@ EVENT_PAGE_SIZE = 1000
 EVENT_API_FIELDS = f"kind,nextPageToken,nextSyncToken,items({EVENT_FIELDS})"
 
 CALENDAR_ID = "calendarId"
+COLORS_URL = "colors"
 CALENDAR_LIST_URL = "users/me/calendarList"
 CALENDAR_GET_URL = "calendars/{calendar_id}"
 CALENDAR_EVENTS_URL = "calendars/{calendar_id}/events"
@@ -359,6 +361,17 @@ class GoogleCalendarService:
             CALENDAR_GET_URL.format(calendar_id=calendar_id)
         )
         return CalendarBasic(**result)
+
+    async def async_get_colors(self) -> Colors:
+        """Return the color definitions for calendars and events.
+
+        This can be used to resolve a `Calendar` colorId or an `Event.color_id`
+        to the corresponding hexadecimal background/foreground color values.
+        The color palette rarely changes, so callers may want to cache the
+        result rather than calling this before every use.
+        """
+        result = await self._auth.get_json(COLORS_URL)
+        return Colors(**result)
 
     async def async_get_event(self, calendar_id: str, event_id: str) -> Event:
         """Return an event based on the event id."""

--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -208,16 +208,13 @@ class Colors(CalendarBaseModel):
     or `event` respectively to resolve the hexadecimal color values.
     """
 
-    kind: Optional[str] = None
-    """Type of the resource, `"calendar#colors"`."""
-
     updated: Optional[datetime.datetime] = None
     """Last modification time of the color palette, as a RFC3339 timestamp."""
 
-    calendar: dict[str, ColorDefinition] = {}
+    calendar: dict[str, ColorDefinition] = Field(default_factory=dict)
     """A map from a `Calendar` colorId to its `ColorDefinition`."""
 
-    event: dict[str, ColorDefinition] = {}
+    event: dict[str, ColorDefinition] = Field(default_factory=dict)
     """A map from an `Event` `color_id` to its `ColorDefinition`."""
 
 

--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -48,6 +48,8 @@ __all__ = [
     "ReminderMethod",
     "AccessRole",
     "CalendarBasic",
+    "ColorDefinition",
+    "Colors",
 ]
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,9 +57,9 @@ _LOGGER = logging.getLogger(__name__)
 
 DATE_STR_FORMAT = "%Y-%m-%d"
 EVENT_FIELDS = (
-    "id,iCalUID,summary,start,end,description,location,transparency,status,eventType,"
-    "visibility,attendees,attendeesOmitted,recurrence,recurringEventId,originalStartTime,"
-    "reminders"
+    "id,iCalUID,summary,start,end,description,location,colorId,transparency,status,"
+    "eventType,visibility,attendees,attendeesOmitted,recurrence,recurringEventId,"
+    "originalStartTime,reminders"
 )
 MIDNIGHT = datetime.time()
 ID_DELIM = "_"
@@ -186,6 +188,37 @@ class Calendar(CalendarBaseModel):
     """The foreground color of the calendar in the hexadecimal format "#ffffff"."""
 
     model_config = ConfigDict(populate_by_name=True)
+
+
+class ColorDefinition(CalendarBaseModel):
+    """A single color definition used by a `Calendar` or `Event`."""
+
+    background: str
+    """The background color in the hexadecimal format "#0088aa"."""
+
+    foreground: str
+    """The foreground color that can be used to write on top of the background color, in the hexadecimal format "#ffffff"."""
+
+
+class Colors(CalendarBaseModel):
+    """The set of colors defined for `Calendar` and `Event` entities.
+
+    Returned by `GoogleCalendarService.async_get_colors`. Use the `calendar_id`
+    of a `Calendar` or the `color_id` of an `Event` as the key into `calendar`
+    or `event` respectively to resolve the hexadecimal color values.
+    """
+
+    kind: Optional[str] = None
+    """Type of the resource, `"calendar#colors"`."""
+
+    updated: Optional[datetime.datetime] = None
+    """Last modification time of the color palette, as a RFC3339 timestamp."""
+
+    calendar: dict[str, ColorDefinition] = {}
+    """A map from a `Calendar` colorId to its `ColorDefinition`."""
+
+    event: dict[str, ColorDefinition] = {}
+    """A map from an `Event` `color_id` to its `ColorDefinition`."""
 
 
 class CalendarBasic(CalendarBaseModel):
@@ -596,6 +629,14 @@ class Event(CalendarBaseModel):
 
     location: Optional[str] = None
     """Geographic location of the event as free-form text."""
+
+    color_id: Optional[str] = Field(alias="colorId", default=None)
+    """The color of the event.
+
+    This is an id referring to an entry in the `event` section of the response
+    returned by `GoogleCalendarService.async_get_colors`, which contains the
+    corresponding hexadecimal background and foreground color values.
+    """
 
     transparency: str = Field(default="opaque")
     """Whether the event blocks time on the calendar.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,7 @@ def mock_app() -> aiohttp.web.Application:
 
     app.router.add_get("/users/me/calendarList", handler)
     app.router.add_get("/calendars/{calendarId}", handler)
+    app.router.add_get("/colors", handler)
 
     app.router.add_get("/calendars/{calendarId}/events", handler)
     app.router.add_post("/calendars/{calendarId}/events", handler)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -83,7 +83,6 @@ async def test_get_colors(
     calendar_service = await calendar_service_cb()
     result = await calendar_service.async_get_colors()
     assert result == Colors(
-        kind="calendar#colors",
         updated=datetime.datetime(
             2012, 4, 26, tzinfo=datetime.timezone.utc
         ),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,6 +17,8 @@ from gcal_sync.model import (
     AccessRole,
     Calendar,
     CalendarBasic,
+    ColorDefinition,
+    Colors,
     DateOrDatetime,
     Event,
     ReminderMethod,
@@ -57,6 +59,39 @@ async def test_get_calendar(
     )
 
     assert url_request() == ["/calendars/primary"]
+
+
+async def test_get_colors(
+    calendar_service_cb: Callable[[], Awaitable[GoogleCalendarService]],
+    json_response: ApiResult,
+    url_request: Callable[[], str],
+) -> None:
+    """Test the colors API used to resolve a colorId to hex values."""
+
+    json_response(
+        {
+            "kind": "calendar#colors",
+            "updated": "2012-04-26T00:00:00.000Z",
+            "calendar": {
+                "1": {"background": "#ac725e", "foreground": "#1d1d1d"},
+            },
+            "event": {
+                "11": {"background": "#dc2127", "foreground": "#1d1d1d"},
+            },
+        },
+    )
+    calendar_service = await calendar_service_cb()
+    result = await calendar_service.async_get_colors()
+    assert result == Colors(
+        kind="calendar#colors",
+        updated=datetime.datetime(
+            2012, 4, 26, tzinfo=datetime.timezone.utc
+        ),
+        calendar={"1": ColorDefinition(background="#ac725e", foreground="#1d1d1d")},
+        event={"11": ColorDefinition(background="#dc2127", foreground="#1d1d1d")},
+    )
+
+    assert url_request() == ["/colors"]
 
 
 async def test_list_calendars(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -858,13 +858,22 @@ def test_colors() -> None:
             },
         }
     )
-    assert colors.kind == "calendar#colors"
     assert colors.calendar["1"] == ColorDefinition(
         background="#ac725e", foreground="#1d1d1d"
     )
     assert colors.event["11"] == ColorDefinition(
         background="#dc2127", foreground="#1d1d1d"
     )
+
+
+def test_colors_default_dicts_are_independent() -> None:
+    """Each Colors instance should get its own dict, not a shared default."""
+
+    colors_a = Colors()
+    colors_b = Colors()
+    colors_a.calendar["1"] = ColorDefinition(background="#ac725e", foreground="#1d1d1d")
+    assert colors_a.calendar
+    assert not colors_b.calendar
 
 
 def test_event_fields_mask() -> None:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -15,6 +15,8 @@ from gcal_sync.model import (
     AccessRole,
     Attendee,
     Calendar,
+    ColorDefinition,
+    Colors,
     DateOrDatetime,
     Event,
     EventStatusEnum,
@@ -121,6 +123,47 @@ def test_event_with_date() -> None:
     assert event.end.timezone is None
     assert event.end.value == datetime.date(2022, 4, 13)
     assert event.timespan.duration == datetime.timedelta(days=1)
+
+
+def test_event_color_id() -> None:
+    """Exercise parsing of an event's colorId field."""
+
+    event = Event.model_validate(
+        {
+            "kind": "calendar#event",
+            "id": "some-event-id",
+            "status": "confirmed",
+            "summary": "Event summary",
+            "colorId": "11",
+            "start": {
+                "date": "2022-04-12",
+            },
+            "end": {
+                "date": "2022-04-13",
+            },
+        }
+    )
+    assert event.color_id == "11"
+
+
+def test_event_color_id_missing() -> None:
+    """An event with no colorId defaults to None."""
+
+    event = Event.model_validate(
+        {
+            "kind": "calendar#event",
+            "id": "some-event-id",
+            "status": "confirmed",
+            "summary": "Event summary",
+            "start": {
+                "date": "2022-04-12",
+            },
+            "end": {
+                "date": "2022-04-13",
+            },
+        }
+    )
+    assert event.color_id is None
 
 
 def test_event_datetime() -> None:
@@ -798,6 +841,30 @@ def test_invalid_rrule_until_time() -> None:
                 "recurrence": ["RRULE:FREQ=WEEKLY;UNTIL=20220202T1234T;BYDAY=TU"],
             }
         )
+
+
+def test_colors() -> None:
+    """Exercise parsing of the colors API response."""
+
+    colors = Colors.model_validate(
+        {
+            "kind": "calendar#colors",
+            "updated": "2012-04-26T00:00:00.000Z",
+            "calendar": {
+                "1": {"background": "#ac725e", "foreground": "#1d1d1d"},
+            },
+            "event": {
+                "11": {"background": "#dc2127", "foreground": "#1d1d1d"},
+            },
+        }
+    )
+    assert colors.kind == "calendar#colors"
+    assert colors.calendar["1"] == ColorDefinition(
+        background="#ac725e", foreground="#1d1d1d"
+    )
+    assert colors.event["11"] == ColorDefinition(
+        background="#dc2127", foreground="#1d1d1d"
+    )
 
 
 def test_event_fields_mask() -> None:


### PR DESCRIPTION
Google Calendar events can have a colorId assigned (e.g. to visually distinguish types of events). This was previously not exposed by the library, forcing consumers to fetch it via a separate raw API call (see e.g. home-assistant/core#156585).

This adds:
- Event.color_id (colorId), included in the EVENT_FIELDS field mask so it is returned by list/get/sync calls.
- New Colors/ColorDefinition models mirroring the Calendar API's colors resource, which maps a colorId to its hex background/ foreground values for both calendars and events.
- GoogleCalendarService.async_get_colors() to fetch that mapping.

Together, Event.color_id can be resolved to a hex value via:
  colors = await service.async_get_colors()
  hex_bg = colors.event[event.color_id].background