### PR TITLE
Add support for the eventLabelId custom color mechanism

### DIFF
--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -50,6 +50,8 @@ __all__ = [
     "CalendarBasic",
     "ColorDefinition",
     "Colors",
+    "EventLabel",
+    "LabelProperties",
 ]
 
 _LOGGER = logging.getLogger(__name__)
@@ -57,9 +59,9 @@ _LOGGER = logging.getLogger(__name__)
 
 DATE_STR_FORMAT = "%Y-%m-%d"
 EVENT_FIELDS = (
-    "id,iCalUID,summary,start,end,description,location,colorId,transparency,status,"
-    "eventType,visibility,attendees,attendeesOmitted,recurrence,recurringEventId,"
-    "originalStartTime,reminders"
+    "id,iCalUID,summary,start,end,description,location,colorId,eventLabelId,"
+    "transparency,status,eventType,visibility,attendees,attendeesOmitted,"
+    "recurrence,recurringEventId,originalStartTime,reminders"
 )
 MIDNIGHT = datetime.time()
 ID_DELIM = "_"
@@ -218,6 +220,35 @@ class Colors(CalendarBaseModel):
     """A map from an `Event` `color_id` to its `ColorDefinition`."""
 
 
+class EventLabel(CalendarBaseModel):
+    """A custom event color label defined on a calendar.
+
+    Part of the newer `eventLabelId`-based color mechanism that supersedes
+    the older index-based `Event.color_id`/`colors` API mechanism, giving
+    calendars up to 200 custom colors instead of a fixed shared palette.
+    """
+
+    id: str
+    """Identifier for this label, referenced by an Event's `event_label_id`."""
+
+    background_color: str = Field(alias="backgroundColor")
+    """The background color for this label, in the hexadecimal format "#0088aa"."""
+
+    name: Optional[str] = None
+    """A human readable name for this label, e.g. "Work" or "Personal"."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class LabelProperties(CalendarBaseModel):
+    """The set of custom event labels defined on a calendar."""
+
+    event_labels: list[EventLabel] = Field(alias="eventLabels", default_factory=list)
+    """The custom event color labels available on this calendar."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class CalendarBasic(CalendarBaseModel):
     """Metadata associated with a calendar from the Get API."""
 
@@ -235,6 +266,16 @@ class CalendarBasic(CalendarBaseModel):
 
     timezone: Optional[str] = Field(alias="timeZone", default=None)
     """The time zone of the calendar."""
+
+    label_properties: Optional[LabelProperties] = Field(
+        alias="labelProperties", default=None
+    )
+    """The calendar's custom event color labels, if any are defined.
+
+    Use an `Event.event_label_id` as the key into this to resolve a hex
+    background color, preferring it over the older `Event.color_id`/
+    `GoogleCalendarService.async_get_colors` mechanism when both are present.
+    """
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -633,6 +674,18 @@ class Event(CalendarBaseModel):
     This is an id referring to an entry in the `event` section of the response
     returned by `GoogleCalendarService.async_get_colors`, which contains the
     corresponding hexadecimal background and foreground color values.
+
+    This is superseded by `event_label_id` when present; see `event_label_id`.
+    """
+
+    event_label_id: Optional[str] = Field(alias="eventLabelId", default=None)
+    """The custom color label assigned to the event, if any.
+
+    Supersedes `color_id`. This is an id referring to an entry in the calendar's
+    own `CalendarBasic.label_properties.event_labels` (see
+    `GoogleCalendarService.async_get_calendar`), which contains the
+    corresponding hexadecimal background color. Prefer this over `color_id`
+    when both are present.
     """
 
     transparency: str = Field(default="opaque")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,8 @@ from gcal_sync.model import (
     Colors,
     DateOrDatetime,
     Event,
+    EventLabel,
+    LabelProperties,
     ReminderMethod,
     ReminderOverride,
     Reminders,
@@ -56,6 +58,47 @@ async def test_get_calendar(
     assert result == CalendarBasic(
         id="calendar-id-1",
         summary="Calendar 1",
+    )
+
+    assert url_request() == ["/calendars/primary"]
+
+
+async def test_get_calendar_with_label_properties(
+    calendar_service_cb: Callable[[], Awaitable[GoogleCalendarService]],
+    json_response: ApiResult,
+    url_request: Callable[[], str],
+) -> None:
+    """Test that async_get_calendar surfaces custom event color labels."""
+
+    json_response(
+        {
+            "id": "calendar-id-1",
+            "summary": "Calendar 1",
+            "labelProperties": {
+                "eventLabels": [
+                    {
+                        "id": "custom-label-42",
+                        "backgroundColor": "#7986cb",
+                        "name": "Focus time",
+                    },
+                ]
+            },
+        },
+    )
+    calendar_service = await calendar_service_cb()
+    result = await calendar_service.async_get_calendar("primary")
+    assert result == CalendarBasic(
+        id="calendar-id-1",
+        summary="Calendar 1",
+        label_properties=LabelProperties(
+            event_labels=[
+                EventLabel(
+                    id="custom-label-42",
+                    background_color="#7986cb",
+                    name="Focus time",
+                )
+            ]
+        ),
     )
 
     assert url_request() == ["/calendars/primary"]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -15,12 +15,15 @@ from gcal_sync.model import (
     AccessRole,
     Attendee,
     Calendar,
+    CalendarBasic,
     ColorDefinition,
     Colors,
     DateOrDatetime,
     Event,
+    EventLabel,
     EventStatusEnum,
     EventTypeEnum,
+    LabelProperties,
     ReminderMethod,
     ReminderOverride,
     ResponseStatus,
@@ -874,6 +877,69 @@ def test_colors_default_dicts_are_independent() -> None:
     colors_a.calendar["1"] = ColorDefinition(background="#ac725e", foreground="#1d1d1d")
     assert colors_a.calendar
     assert not colors_b.calendar
+
+
+def test_event_label_id() -> None:
+    """Exercise parsing of an event's eventLabelId field."""
+
+    event = Event.model_validate(
+        {
+            "kind": "calendar#event",
+            "id": "some-event-id",
+            "status": "confirmed",
+            "summary": "Event summary",
+            "colorId": "11",
+            "eventLabelId": "custom-label-42",
+            "start": {"date": "2022-04-12"},
+            "end": {"date": "2022-04-13"},
+        }
+    )
+    # Both may be present at once; event_label_id supersedes color_id.
+    assert event.color_id == "11"
+    assert event.event_label_id == "custom-label-42"
+
+
+def test_calendar_basic_label_properties() -> None:
+    """Exercise parsing of a calendar's custom event color labels."""
+
+    calendar = CalendarBasic.model_validate(
+        {
+            "kind": "calendar#calendar",
+            "id": "some-calendar-id",
+            "summary": "Test Calendar",
+            "labelProperties": {
+                "eventLabels": [
+                    {
+                        "id": "custom-label-42",
+                        "backgroundColor": "#7986cb",
+                        "name": "Focus time",
+                    },
+                ]
+            },
+        }
+    )
+    assert calendar.label_properties == LabelProperties(
+        event_labels=[
+            EventLabel(
+                id="custom-label-42",
+                background_color="#7986cb",
+                name="Focus time",
+            )
+        ]
+    )
+
+
+def test_calendar_basic_no_label_properties() -> None:
+    """A calendar with no custom labels has label_properties=None."""
+
+    calendar = CalendarBasic.model_validate(
+        {
+            "kind": "calendar#calendar",
+            "id": "some-calendar-id",
+            "summary": "Test Calendar",
+        }
+    )
+    assert calendar.label_properties is None
 
 
 def test_event_fields_mask() -> None:


### PR DESCRIPTION
Google recently expanded event colors from a fixed 11-color palette to up to 200 custom colors per calendar (announced June 2026: https://workspaceupdates.googleblog.com/2026/06/custom-event-colors-in-google-calendar.html).

This is exposed via a new mechanism that supersedes the old colorId:
- Event.eventLabelId: references a custom label defined on the calendar itself, rather than a fixed shared palette entry.
- Calendar (via the Get API): new labelProperties.eventLabels, each with an id, a backgroundColor (hex, no separate colors.get() call needed), and an optional name.

Adds:
- Event.event_label_id (colorId is kept for backwards compatibility with older events/clients; event_label_id should be preferred when present).
- CalendarBasic.label_properties (via GoogleCalendarService.async_get_calendar), with new EventLabel/LabelProperties models.
- eventLabelId added to EVENT_FIELDS.

No API/endpoint changes needed for reading: labelProperties is included in the existing calendars.get() response with no fields mask restricting it. Writing eventLabelId requires an eventLabelVersion=1 query param per Google's docs, out of scope for this read-focused change.