### PR TITLE
feat: support writerWithoutPrivateAccess access role and unknown fallback

### DIFF
--- a/gcal_sync/model.py
+++ b/gcal_sync/model.py
@@ -100,10 +100,20 @@ class AccessRole(str, Enum):
     OWNER = "owner"
     """Provides ownership of the calendar."""
 
+    WRITER_WITHOUT_PRIVATE_ACCESS = "writerWithoutPrivateAccess"
+    """Provides read and write access to the calendar without private event details."""
+
+    UNKNOWN = "unknown"
+    """An unknown access role."""
+
     @property
     def is_writer(self) -> bool:
         """Return if this role can create, delete, update events."""
-        return self in (AccessRole.WRITER, AccessRole.OWNER)
+        return self in (
+            AccessRole.WRITER,
+            AccessRole.OWNER,
+            AccessRole.WRITER_WITHOUT_PRIVATE_ACCESS,
+        )
 
 
 def _raise_parse_exception(
@@ -187,6 +197,20 @@ class Calendar(CalendarBaseModel):
     """The foreground color of the calendar in the hexadecimal format "#ffffff"."""
 
     model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _adjust_unknown_access_role(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Validate the access role."""
+        key = "accessRole" if "accessRole" in values else "access_role"
+        if (
+            (access_role := values.get(key))
+            and isinstance(access_role, str)
+            and access_role not in [member.value for member in AccessRole]
+        ):
+            _LOGGER.debug("Unknown access role: %s", access_role)
+            values[key] = AccessRole.UNKNOWN
+        return values
 
 
 class ColorDefinition(CalendarBaseModel):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -110,6 +110,16 @@ async def test_list_calendars(
                     "summary": "Calendar 2",
                     "accessRole": "owner",
                 },
+                {
+                    "id": "calendar-id-3",
+                    "summary": "Calendar 3",
+                    "accessRole": "writerWithoutPrivateAccess",
+                },
+                {
+                    "id": "calendar-id-4",
+                    "summary": "Calendar 4",
+                    "accessRole": "unexpectedRole",
+                },
             ]
         }
     )
@@ -121,6 +131,16 @@ async def test_list_calendars(
         ),
         Calendar(
             id="calendar-id-2", summary="Calendar 2", access_role=AccessRole.OWNER
+        ),
+        Calendar(
+            id="calendar-id-3",
+            summary="Calendar 3",
+            access_role=AccessRole.WRITER_WITHOUT_PRIVATE_ACCESS,
+        ),
+        Calendar(
+            id="calendar-id-4",
+            summary="Calendar 4",
+            access_role=AccessRole.UNKNOWN,
         ),
     ]
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -86,6 +86,39 @@ def test_calendar_timezone() -> None:
     assert calendar.foreground_color is None
 
 
+@pytest.mark.parametrize(
+    "api_access_role,access_role",
+    [
+        ("freeBusyReader", AccessRole.FREE_BUSY_READER),
+        ("reader", AccessRole.READER),
+        ("writer", AccessRole.WRITER),
+        ("owner", AccessRole.OWNER),
+        ("writerWithoutPrivateAccess", AccessRole.WRITER_WITHOUT_PRIVATE_ACCESS),
+        ("some-unknown-role", AccessRole.UNKNOWN),
+    ],
+)
+def test_calendar_access_role(api_access_role: str, access_role: AccessRole) -> None:
+    """Test parsing access roles in a calendar."""
+    calendar = Calendar.model_validate(
+        {
+            "id": "some-calendar-id",
+            "summary": "Calendar summary",
+            "accessRole": api_access_role,
+        }
+    )
+    assert calendar.access_role == access_role
+
+
+def test_calendar_unknown_access_role_by_alias() -> None:
+    """Test instantiating calendar with unknown access role using attribute name."""
+    calendar = Calendar(
+        id="some-calendar-id",
+        summary="Calendar summary",
+        access_role="unknown-role",  # type: ignore[arg-type]
+    )
+    assert calendar.access_role == AccessRole.UNKNOWN
+
+
 def test_event_with_date() -> None:
     """Exercise basic parsing of an event API response."""
 
@@ -950,6 +983,8 @@ def test_invalid_event_id(event_id: str) -> None:
         (AccessRole.READER, False),
         (AccessRole.WRITER, True),
         (AccessRole.OWNER, True),
+        (AccessRole.WRITER_WITHOUT_PRIVATE_ACCESS, True),
+        (AccessRole.UNKNOWN, False),
     ],
 )
 def test_access_role_writer(access_role: AccessRole, writer: bool) -> None:


### PR DESCRIPTION
## Description

This PR fixes [home-assistant/core#181232](https://github.com/home-assistant/core/issues/181232) where Google Calendar integration setup fails when `calendarList` returns `accessRole: "writerWithoutPrivateAccess"`.

### Changes
- Add `AccessRole.WRITER_WITHOUT_PRIVATE_ACCESS = "writerWithoutPrivateAccess"` with `is_writer = True`.
- Add `AccessRole.UNKNOWN = "unknown"` with `is_writer = False`.
- Add `_adjust_unknown_access_role` before-validator on `Calendar` to safely map any unrecognized access roles to `AccessRole.UNKNOWN` instead of raising a parse exception and dropping all calendars.
- Add unit tests for `AccessRole` and calendar parsing, including end-to-end API response testing.

Fixes https://github.com/home-assistant/core/issues/181232